### PR TITLE
docs: simplify software documentation index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,3 @@
 # Software Documentation
 
-Use the documents in this directory for software behavior, runtime configuration, and integration guidance.
-
-- `architecture.md`: system structure, processing flows, and trust boundaries
-- `configuration.md`: environment variables and runtime tuning
-- `auth.md`: JWT auth modes, authorization model, and permission file behavior
-- `rpc.md`: REST-facing RPC usage and control-plane behavior
+Reference documentation for hub architecture, configuration, authentication, and RPC behavior.


### PR DESCRIPTION
Simplifies the software documentation index page by removing the redundant markdown file list and leaving a short summary so the generated documentation cards serve as the primary navigation.