### PR TITLE
[codex] Add GTFS MQTT connector and connector docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Notes:
 - [docs/configuration.md](docs/configuration.md)
 - [docs/auth.md](docs/auth.md)
 - [docs/rpc.md](docs/rpc.md)
+- [docs/connectors.md](docs/connectors.md)
+- [docs/connectors-websocket.md](docs/connectors-websocket.md)
+- [docs/connectors-mqtt.md](docs/connectors-mqtt.md)
 
 ## Connector Demonstrators
 - [connectors/README.md](connectors/README.md)

--- a/connectors/gtfs/.env.example
+++ b/connectors/gtfs/.env.example
@@ -1,7 +1,15 @@
 # Hub endpoints
 HUB_HTTP_URL=http://localhost:8080
 HUB_WS_URL=ws://localhost:8080/v2/ws/socket
+MQTT_BROKER_URL=tcp://localhost:1883
 HUB_TOKEN=
+
+# Optional MQTT auth and tuning
+GTFS_MQTT_CLIENT_ID=
+GTFS_MQTT_USERNAME=
+GTFS_MQTT_PASSWORD=
+GTFS_MQTT_KEEPALIVE_SECONDS=30
+GTFS_MQTT_QOS=1
 
 # Upstream feeds
 GTFS_STATIC_URL=https://transport.data.gouv.fr/resources/81254/download

--- a/connectors/gtfs/README.md
+++ b/connectors/gtfs/README.md
@@ -1,8 +1,9 @@
 # GTFS Connector Demonstrator
 
 This demonstrator forwards GTFS-RT vehicle positions to a locally running Open
-RTLS Hub over the OMLOX WebSocket `location_updates` topic and bootstraps
-station zones and polygon fences for arrival and departure tracking.
+RTLS Hub and bootstraps station zones and polygon fences for arrival and
+departure tracking. The repository includes both a WebSocket ingest variant and
+an MQTT ingest variant.
 
 The checked-in defaults target the live Grand Dole network:
 
@@ -16,9 +17,17 @@ The checked-in defaults target the live Grand Dole network:
 
 - `connector.py`: polls GTFS-RT vehicle positions and publishes OMLOX
   `location_updates` over WebSocket
+- `connector_mqtt.py`: polls GTFS-RT vehicle positions and publishes OMLOX
+  `Location` payloads to the MQTT ingest topic
+  `/omlox/json/location_updates/pub/{provider_id}`
 - `station_polygons.py`: creates one station `Zone` and one station `Fence` per
   station in the hub
-- `hub_client.py`: shared REST and WebSocket helper code
+- `scripts/log_locations.py`: subscribes to `location_updates` and writes NDJSON
+- `scripts/log_fence_events.py`: subscribes to `fence_events` and writes NDJSON
+- `scripts/log_collision_events.py`: subscribes to `collision_events` and writes NDJSON
+- `scripts/check_geofence_alignment.py`: compares logged locations against the
+  current station fences
+- `hub_client.py`: shared REST, WebSocket, and MQTT helper code
 - `gtfs_support.py`: GTFS parsing, GTFS-RT decoding, and station polygon
   generation helpers
 - `.env.example`: environment template
@@ -46,6 +55,7 @@ connectors/local-hub/fetch_demo_token.sh
 
 - `HUB_HTTP_URL`: base URL for REST bootstrap calls such as `http://localhost:8080`
 - `HUB_WS_URL`: WebSocket endpoint such as `ws://localhost:8080/v2/ws/socket`
+- `MQTT_BROKER_URL`: MQTT broker URL such as `tcp://localhost:1883`
 - `HUB_TOKEN`: optional JWT access token; required when hub auth is enabled
 - `GTFS_STATIC_URL`: GTFS zip URL or local path
 - `GTFS_RT_URL`: GTFS-RT protobuf URL
@@ -62,6 +72,11 @@ Optional filters and tuning:
 - `GTFS_STATION_POLYGON_MODE`: `circle`, `auto`, or `hull`
 - `GTFS_STATION_RADIUS_METERS`: radius used for circle-based station fences
 - `GTFS_STATION_HULL_BUFFER_METERS`: outward expansion applied to hull polygons
+- `GTFS_MQTT_CLIENT_ID`: optional MQTT client ID override for `connector_mqtt.py`
+- `GTFS_MQTT_USERNAME`: optional MQTT username for `connector_mqtt.py`
+- `GTFS_MQTT_PASSWORD`: optional MQTT password for `connector_mqtt.py`
+- `GTFS_MQTT_KEEPALIVE_SECONDS`: MQTT keepalive for `connector_mqtt.py`
+- `GTFS_MQTT_QOS`: MQTT publish QoS for `connector_mqtt.py`
 
 ## Setup
 
@@ -92,10 +107,11 @@ uv sync --project connectors/gtfs
 uv run --project connectors/gtfs python connectors/gtfs/station_polygons.py --env-file connectors/gtfs/.env.local
 ```
 
-6. Start the connector:
+6. Start either connector:
 
 ```bash
 uv run --project connectors/gtfs python connectors/gtfs/connector.py --env-file connectors/gtfs/.env.local
+uv run --project connectors/gtfs python connectors/gtfs/connector_mqtt.py --env-file connectors/gtfs/.env.local
 ```
 
 7. Optional: record live WebSocket topics to NDJSON with the shared root scripts:
@@ -110,13 +126,14 @@ For a single GTFS-RT fetch during local testing:
 
 ```bash
 uv run --project connectors/gtfs python connectors/gtfs/connector.py --env-file connectors/gtfs/.env.local --once
+uv run --project connectors/gtfs python connectors/gtfs/connector_mqtt.py --env-file connectors/gtfs/.env.local --once
 ```
 
 ## Hub Mapping
 
 ### Vehicle updates
 
-The connector publishes OMLOX WebSocket wrapper messages shaped like:
+The WebSocket connector publishes OMLOX wrapper messages shaped like:
 
 ```json
 {
@@ -146,6 +163,17 @@ Runtime mapping details:
 - vehicle IDs are mapped to deterministic trackable UUIDs and upserted through
   `/v2/trackables`
 - trip, route, stop, and vehicle metadata are copied into `Location.properties`
+
+The MQTT connector publishes the same normalized `Location` objects as plain
+JSON message bodies on:
+
+```text
+/omlox/json/location_updates/pub/{provider_id}
+```
+
+That lets the hub process the same GTFS-derived locations through the MQTT
+ingest surface and then republish normalized output to the normal downstream
+MQTT and WebSocket topics.
 
 ### Station zones and fences
 

--- a/connectors/gtfs/connector_mqtt.py
+++ b/connectors/gtfs/connector_mqtt.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Forward GTFS-RT vehicle positions to a local Open RTLS Hub over MQTT."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import time
+
+from connector import build_locations, require_env
+from gtfs_support import fetch_gtfs_rt_feed, load_env_file, load_gtfs_index
+from hub_client import HubConfig, HubMQTTPublisher, HubRESTClient
+
+
+LOGGER = logging.getLogger("gtfs.connector_mqtt")
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env-file", default=os.getenv("GTFS_ENV_FILE"))
+    parser.add_argument("--once", action="store_true", help="Process one GTFS-RT fetch and exit")
+    return parser
+
+
+def main() -> int:
+    args = build_argument_parser().parse_args()
+    load_env_file(args.env_file)
+
+    logging.basicConfig(
+        level=os.getenv("LOG_LEVEL", "INFO").upper(),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    gtfs_static_url = require_env("GTFS_STATIC_URL")
+    gtfs_rt_url = require_env("GTFS_RT_URL")
+    provider_id = os.getenv("GTFS_PROVIDER_ID", "gtfs-demo")
+    provider_type = os.getenv("GTFS_PROVIDER_TYPE", "gtfs-rt")
+    provider_name = os.getenv("GTFS_PROVIDER_NAME", "GTFS Demonstrator")
+    route_filter = os.getenv("GTFS_ROUTE_FILTER") or None
+    poll_interval = float(os.getenv("GTFS_POLL_INTERVAL_SECONDS", "15"))
+
+    hub_config = HubConfig(
+        http_url=require_env("HUB_HTTP_URL"),
+        mqtt_broker_url=require_env("MQTT_BROKER_URL"),
+        mqtt_client_id=os.getenv("GTFS_MQTT_CLIENT_ID") or None,
+        mqtt_username=os.getenv("GTFS_MQTT_USERNAME") or None,
+        mqtt_password=os.getenv("GTFS_MQTT_PASSWORD") or None,
+        mqtt_keepalive_seconds=int(os.getenv("GTFS_MQTT_KEEPALIVE_SECONDS", "30")),
+        mqtt_qos=int(os.getenv("GTFS_MQTT_QOS", "1")),
+        token=os.getenv("HUB_TOKEN") or None,
+    )
+    hub_rest = HubRESTClient(hub_config)
+    hub_mqtt = HubMQTTPublisher(hub_config)
+
+    gtfs = load_gtfs_index(gtfs_static_url)
+    LOGGER.info("loaded GTFS index with %d stations and %d trips", len(gtfs.stations), len(gtfs.trips))
+
+    hub_rest.ensure_provider(
+        provider_id=provider_id,
+        provider_type=provider_type,
+        name=provider_name,
+        properties={"connector": "gtfs", "transport": "mqtt"},
+    )
+
+    known_trackables: set[str] = set()
+    try:
+        while True:
+            feed = fetch_gtfs_rt_feed(gtfs_rt_url)
+            locations = build_locations(
+                feed=feed,
+                gtfs=gtfs,
+                provider_id=provider_id,
+                provider_type=provider_type,
+                route_filter=route_filter,
+                hub_rest=hub_rest,
+                known_trackables=known_trackables,
+            )
+            if locations:
+                LOGGER.info("publishing %d location updates over MQTT", len(locations))
+                hub_mqtt.publish_locations(provider_id, locations)
+            else:
+                LOGGER.info("no matching vehicle positions in current feed")
+
+            if args.once:
+                return 0
+            time.sleep(poll_interval)
+    finally:
+        hub_mqtt.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/connectors/gtfs/hub_client.py
+++ b/connectors/gtfs/hub_client.py
@@ -9,8 +9,9 @@ import time
 import uuid
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
+import paho.mqtt.client as mqtt
 import requests
 import websocket
 
@@ -34,7 +35,13 @@ def point(longitude: float, latitude: float) -> dict[str, Any]:
 @dataclass
 class HubConfig:
     http_url: str
-    ws_url: str
+    ws_url: str | None = None
+    mqtt_broker_url: str | None = None
+    mqtt_client_id: str | None = None
+    mqtt_username: str | None = None
+    mqtt_password: str | None = None
+    mqtt_keepalive_seconds: int = 30
+    mqtt_qos: int = 1
     token: str | None = None
     timeout_seconds: float = 30.0
 
@@ -216,3 +223,91 @@ class HubWebSocketPublisher:
             except Exception:
                 LOGGER.debug("websocket close failed", exc_info=True)
             self._connection = None
+
+
+class HubMQTTPublisher:
+    """HubMQTTPublisher publishes OMLOX location payloads over MQTT."""
+
+    def __init__(self, config: HubConfig):
+        if not config.mqtt_broker_url:
+            raise ValueError("mqtt_broker_url is required for MQTT publishing")
+
+        self.config = config
+        self._client = mqtt.Client(
+            callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
+            client_id=config.mqtt_client_id or "",
+        )
+        if config.mqtt_username:
+            self._client.username_pw_set(config.mqtt_username, config.mqtt_password)
+        self._client.reconnect_delay_set(min_delay=1, max_delay=30)
+        self._client.on_connect = self._on_connect
+        self._client.on_disconnect = self._on_disconnect
+
+        self._connected = threading.Event()
+        self._stopped = False
+        self._connect()
+        self._client.loop_start()
+
+    def close(self) -> None:
+        self._stopped = True
+        self._client.loop_stop()
+        try:
+            self._client.disconnect()
+        except Exception:
+            LOGGER.debug("mqtt disconnect failed", exc_info=True)
+
+    def publish_locations(self, provider_id: str, locations: list[dict[str, Any]]) -> None:
+        if not locations:
+            return
+        self._wait_connected()
+        topic = f"/omlox/json/location_updates/pub/{provider_id}"
+        for location in locations:
+            payload = json.dumps(location)
+            info = self._client.publish(topic, payload=payload, qos=self.config.mqtt_qos, retain=False)
+            info.wait_for_publish()
+            if info.rc != mqtt.MQTT_ERR_SUCCESS:
+                raise RuntimeError(f"mqtt publish failed for {topic}: rc={info.rc}")
+
+    def _connect(self) -> None:
+        parsed = urlparse(self.config.mqtt_broker_url or "")
+        if parsed.scheme not in {"tcp", "mqtt"}:
+            raise ValueError(
+                f"unsupported MQTT broker URL scheme {parsed.scheme!r}; use tcp:// or mqtt://"
+            )
+        host = parsed.hostname
+        if not host:
+            raise ValueError("MQTT broker URL must include a hostname")
+        port = parsed.port or 1883
+        LOGGER.info("connecting mqtt publisher to %s", self.config.mqtt_broker_url)
+        self._client.connect(host, port=port, keepalive=self.config.mqtt_keepalive_seconds)
+
+    def _wait_connected(self) -> None:
+        if not self._connected.wait(timeout=self.config.timeout_seconds):
+            raise RuntimeError("mqtt connect timed out")
+
+    def _on_connect(
+        self,
+        _client: mqtt.Client,
+        _userdata: Any,
+        _flags: mqtt.ConnectFlags,
+        reason_code: mqtt.ReasonCode,
+        _properties: mqtt.Properties | None = None,
+    ) -> None:
+        if reason_code.is_failure:
+            LOGGER.warning("mqtt connect failed: %s", reason_code)
+            self._connected.clear()
+            return
+        LOGGER.info("mqtt connected")
+        self._connected.set()
+
+    def _on_disconnect(
+        self,
+        _client: mqtt.Client,
+        _userdata: Any,
+        _flags: mqtt.DisconnectFlags,
+        reason_code: mqtt.ReasonCode,
+        _properties: mqtt.Properties | None = None,
+    ) -> None:
+        self._connected.clear()
+        if not self._stopped:
+            LOGGER.warning("mqtt disconnected: %s", reason_code)

--- a/connectors/gtfs/pyproject.toml
+++ b/connectors/gtfs/pyproject.toml
@@ -5,6 +5,7 @@ description = "GTFS demonstrator connector for Open RTLS Hub"
 requires-python = ">=3.12"
 dependencies = [
   "gtfs-realtime-bindings>=2.0.0",
+  "paho-mqtt>=2.1.0",
   "protobuf>=7.0.0",
   "pyproj>=3.7.0",
   "requests>=2.33.0",

--- a/connectors/gtfs/uv.lock
+++ b/connectors/gtfs/uv.lock
@@ -111,6 +111,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "gtfs-realtime-bindings" },
+    { name = "paho-mqtt" },
     { name = "protobuf" },
     { name = "pyproj" },
     { name = "requests" },
@@ -120,10 +121,20 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "gtfs-realtime-bindings", specifier = ">=2.0.0" },
+    { name = "paho-mqtt", specifier = ">=2.1.0" },
     { name = "protobuf", specifier = ">=7.0.0" },
     { name = "pyproj", specifier = ">=3.7.0" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "websocket-client", specifier = ">=1.9.0" },
+]
+
+[[package]]
+name = "paho-mqtt"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/15/0a6214e76d4d32e7f663b109cf71fb22561c2be0f701d67f93950cd40542/paho_mqtt-2.1.0.tar.gz", hash = "sha256:12d6e7511d4137555a3f6ea167ae846af2c7357b10bc6fa4f7c3968fc1723834", size = 148848, upload-time = "2024-04-29T19:52:55.591Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/cb/00451c3cf31790287768bb12c6bec834f5d292eaf3022afc88e14b8afc94/paho_mqtt-2.1.0-py3-none-any.whl", hash = "sha256:6db9ba9b34ed5bc6b6e3812718c7e06e2fd7444540df2455d2c51bd58808feee", size = 67219, upload-time = "2024-04-29T19:52:48.345Z" },
 ]
 
 [[package]]

--- a/docs/connectors-mqtt.md
+++ b/docs/connectors-mqtt.md
@@ -1,0 +1,139 @@
+# Connector Guide: MQTT
+
+Use MQTT when your deployment already centers on a broker, when trusted edge
+adapters naturally publish broker messages, or when broker-based routing fits
+better than a long-lived WebSocket client connection.
+
+This repository ships a concrete MQTT connector example in
+[`connectors/gtfs/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/gtfs/README.md).
+The MQTT connector path is documented here against the hub's implemented OMLOX
+MQTT surface. Transport details live in
+[`specifications/omlox/mqtt.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/specifications/omlox/mqtt.md).
+
+## When To Choose MQTT
+
+Choose MQTT when:
+
+- your source system already publishes to a broker
+- you are running trusted local or edge adapters near devices
+- you want broker-native fan-out, retention, or topic-based routing
+- WebSocket is not the natural operational fit for the connector process
+
+For user-facing applications and general connector examples, WebSocket is often
+the simpler starting point. See
+[docs/connectors-websocket.md](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/docs/connectors-websocket.md).
+
+## Required Inputs
+
+An MQTT-based connector usually needs:
+
+- `HUB_HTTP_URL`: REST base URL for optional metadata bootstrap
+- `MQTT_BROKER_URL`: broker URL such as `tcp://localhost:1883`
+- MQTT client identity and auth settings that fit your deployment
+- `HUB_TOKEN` only if the connector also uses REST against an auth-enabled hub
+
+The hub's runtime broker URL is documented in
+[`docs/configuration.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/docs/configuration.md).
+
+## Minimal Runtime Flow
+
+The connector shape is almost the same as the WebSocket path:
+
+1. Load environment variables.
+2. Optionally use REST to ensure the provider and other metadata exist.
+3. Connect to the MQTT broker.
+4. Map upstream data to OMLOX payloads.
+5. Publish each payload to the correct OMLOX ingest topic.
+6. Optionally subscribe to hub-generated output topics for validation.
+7. Reconnect and retry when broker connectivity fails.
+
+The main difference is transport mapping. Instead of sending an OMLOX wrapper,
+the connector publishes the payload body directly on the correct topic.
+
+## Inbound Versus Outbound Topics
+
+MQTT connector authors need to keep one boundary clear:
+
+- inbound ingest topics are written by the connector and consumed by the hub
+- outbound topics are written by the hub after it processes or derives data
+
+Examples from the existing MQTT mapping:
+
+- connector writes location ingest to
+  `/omlox/json/location_updates/pub/{provider_id}`
+- connector writes proximity ingest to
+  `/omlox/json/proximity_updates/{source}/{provider_id}`
+- hub writes processed locations to
+  `/omlox/json/location_updates/local/{provider_id}` and
+  `/omlox/json/location_updates/epsg4326/{provider_id}`
+- hub writes derived events to topic families such as `fence_events`,
+  `trackable_motions`, and `collision_events`
+
+Do not publish directly to the hub-generated output topics. Those exist so the
+hub can publish normalized or derived results after it processes the inbound
+payload.
+
+## Topic Selection
+
+The correct topic depends on the payload type:
+
+- publish `Location` ingest to
+  `/omlox/json/location_updates/pub/{provider_id}`
+- publish `Proximity` ingest to
+  `/omlox/json/proximity_updates/{source}/{provider_id}`
+- consume processed and derived hub output from the output topic families when
+  you need validation or downstream processing
+
+Use
+[`specifications/omlox/mqtt.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/specifications/omlox/mqtt.md)
+as the source of truth for topic families and payload expectations.
+
+## Example Ingest Shape
+
+For MQTT, the message body is the normalized OMLOX object itself. For example,
+a connector publishing a location update would send a `Location` JSON payload to
+`/omlox/json/location_updates/pub/{provider_id}`:
+
+```json
+{
+  "position": { "type": "Point", "coordinates": [8.5705, 50.0333] },
+  "crs": "EPSG:4326",
+  "provider_id": "my-connector",
+  "provider_type": "virtual",
+  "source": "upstream:object-123"
+}
+```
+
+## Reusing The Bundled Connector Pattern
+
+Even though the transport changes, the overall connector design can stay the
+same as the bundled examples:
+
+- keep env-driven configuration
+- keep a small REST helper for metadata bootstrap
+- keep the upstream polling or subscription loop separate from the transport
+  client
+- keep mapping code focused on OMLOX payload construction
+
+These repository examples are the best templates for that structure:
+
+- [`connectors/gtfs/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/gtfs/README.md):
+  includes both a WebSocket connector and an MQTT connector that publish the
+  same normalized GTFS-derived `Location` payloads
+- [`connectors/opensky/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/opensky/README.md)
+
+The GTFS project is now the direct MQTT example. The OpenSky project remains a
+useful example for shared project layout, env handling, and REST bootstrap.
+
+## Local Run Path
+
+For local development, use the shared demo stack:
+
+```bash
+connectors/local-hub/start_demo.sh
+```
+
+That stack includes the hub, Postgres, Dex, and Mosquitto. See
+[`connectors/local-hub/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/local-hub/README.md)
+for the local runtime details and the token helper if your connector also uses
+REST against an auth-enabled hub.

--- a/docs/connectors-websocket.md
+++ b/docs/connectors-websocket.md
@@ -1,0 +1,155 @@
+# Connector Guide: WebSocket
+
+Use WebSocket when you want the simplest connector path into the hub. It maps
+well to the current bundled demos, it works cleanly with the hub's auth model,
+and it does not require you to design topic routing beyond the OMLOX WebSocket
+topic names.
+
+The bundled connector demonstrators in this repository currently use this
+approach:
+
+- [`connectors/gtfs/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/gtfs/README.md)
+- [`connectors/opensky/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/opensky/README.md)
+
+Protocol details live in
+[`specifications/omlox/websocket.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/specifications/omlox/websocket.md).
+
+## When To Choose WebSocket
+
+Choose WebSocket when:
+
+- your connector is an application-style process that already manages a direct
+  connection to the hub
+- you want the same ingest path as the bundled examples
+- you want per-message auth through `params.token`
+- you want to subscribe to hub topics for validation, logging, or downstream
+  processing in the same transport family
+
+## Required Inputs
+
+Most WebSocket-based connectors need:
+
+- `HUB_HTTP_URL`: REST base URL for metadata bootstrap such as
+  `http://localhost:8080`
+- `HUB_WS_URL`: WebSocket endpoint such as `ws://localhost:8080/v2/ws/socket`
+- `HUB_TOKEN`: optional JWT access token; required when auth is enabled
+
+The bundled examples also keep upstream URLs, polling intervals, provider IDs,
+and source-specific settings in environment variables.
+
+## Minimal Runtime Flow
+
+The common flow is:
+
+1. Load environment variables.
+2. Create a REST client for provider or trackable upserts when needed.
+3. Open a WebSocket connection to `GET /v2/ws/socket`.
+4. Map upstream data to OMLOX payloads.
+5. Send wrapper `message` events to the right topic.
+6. Reconnect and retry when the socket breaks.
+
+The bundled helper modules also keep the connection alive with periodic ping
+frames and reconnect on send failure.
+
+## Publish Shape
+
+For ingest, the connector sends OMLOX wrapper messages. A typical
+`location_updates` publish looks like this:
+
+```json
+{
+  "event": "message",
+  "topic": "location_updates",
+  "payload": [
+    {
+      "position": { "type": "Point", "coordinates": [8.5705, 50.0333] },
+      "crs": "EPSG:4326",
+      "provider_id": "my-connector",
+      "provider_type": "virtual",
+      "source": "upstream:object-123"
+    }
+  ],
+  "params": {
+    "token": "..."
+  }
+}
+```
+
+Notes:
+
+- `payload` is an array, even when you only send one item
+- omit `params.token` only when hub auth is disabled
+- publish to the topic that matches the payload type and intended behavior
+- `location_updates` is the normal entry point for live location ingest
+
+## Subscribe Shape
+
+The same transport can be used to observe hub output topics. A minimal
+subscription message looks like this:
+
+```json
+{
+  "event": "subscribe",
+  "topic": "fence_events",
+  "params": {
+    "token": "..."
+  }
+}
+```
+
+This is useful when you want to:
+
+- validate what the hub emits after ingest
+- capture NDJSON logs during local testing
+- confirm that your metadata bootstrap and location mapping behave as expected
+
+## Metadata Bootstrap
+
+Most connectors need more than a socket sender. The bundled examples also use
+REST for idempotent metadata setup:
+
+- create or update the `LocationProvider`
+- upsert `Trackable` resources when the upstream source has stable asset IDs
+- optionally create `Zone` and `Fence` resources before ingest starts
+
+That split is usually the easiest connector design:
+
+- REST for durable metadata and bootstrap
+- WebSocket for live ingest and optional subscriptions
+
+## Local Run Path
+
+For local development:
+
+1. Start the shared demo runtime:
+
+```bash
+connectors/local-hub/start_demo.sh
+```
+
+2. Fetch a token when auth is enabled:
+
+```bash
+connectors/local-hub/fetch_demo_token.sh
+```
+
+3. Run your connector against the local hub with `HUB_HTTP_URL`,
+   `HUB_WS_URL`, and optionally `HUB_TOKEN`.
+
+See
+[`connectors/local-hub/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/local-hub/README.md)
+for the reusable local stack.
+
+## Example Projects
+
+Use these as concrete WebSocket examples:
+
+- [`connectors/gtfs/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/gtfs/README.md):
+  REST bootstrap for provider, trackables, stations, and fences, then live
+  `location_updates` publish over WebSocket
+- [`connectors/opensky/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/opensky/README.md):
+  REST bootstrap for provider, trackables, and airport fences, then live
+  `location_updates` publish over WebSocket
+
+If you want to build your own connector quickly, copying one of those patterns
+is the shortest path.

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -1,0 +1,127 @@
+# Connectors
+
+This repository keeps connectors outside the hub runtime. A connector is a
+small process that reads data from some upstream system, maps that data to the
+hub's OMLOX-facing model, and submits it through the hub's supported transport
+surfaces.
+
+The key point is simple: creating a connector is easy. You do not need to patch
+the hub. In most cases you only need:
+
+1. a small runtime loop that reads upstream data
+2. some mapping code that builds OMLOX `Location` or `Proximity` payloads
+3. optional REST bootstrap calls for providers, trackables, zones, or fences
+4. a transport publisher for WebSocket or MQTT
+
+## Bundled Connector Examples
+
+The repository already includes a few connector-oriented projects under
+[`connectors/`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors):
+
+- [`connectors/local-hub/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/local-hub/README.md):
+  shared local hub, Postgres, Dex, and Mosquitto demo runtime
+- [`connectors/gtfs/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/gtfs/README.md):
+  GTFS-RT vehicle ingest plus station-zone and fence bootstrap
+- [`connectors/opensky/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/opensky/README.md):
+  OpenSky aircraft ingest plus airport fence bootstrap
+
+The bundled runtime connectors now cover both transport styles. The GTFS
+project includes WebSocket and MQTT ingest variants, and the OpenSky project
+shows the WebSocket path. Together they are useful examples for connector
+structure, env handling, bootstrap logic, and local development flow.
+
+## Easy Path
+
+Most custom connectors follow the same shape:
+
+1. Pick a transport.
+   Use WebSocket when you want the simplest general-purpose hub-facing ingest
+   path. Use MQTT when your deployment already centers on a broker or trusted
+   edge adapters.
+2. Prepare env-driven config.
+   Keep hub URLs, broker settings, auth tokens, upstream URLs, and poll
+   intervals in environment variables.
+3. Create or reconcile hub metadata when needed.
+   Many connectors need a `LocationProvider` and sometimes `Trackable`, `Zone`,
+   or `Fence` resources before live ingest starts.
+4. Map upstream records to OMLOX payloads.
+   Normalize each upstream event to a hub payload such as `Location` or
+   `Proximity`.
+5. Publish to the hub.
+   Send those normalized payloads over WebSocket or MQTT using the transport's
+   expected wrapper or topic layout.
+6. Run locally against the shared demo stack.
+   Use [`connectors/local-hub/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/local-hub/README.md)
+   for a reproducible local hub, Postgres, Dex, and Mosquitto environment.
+
+## Shared Connector Shape
+
+The bundled connectors show a practical split that is easy to copy:
+
+- one runtime script that polls or subscribes to the upstream source
+- one small client helper module for hub REST and transport calls
+- optional bootstrap scripts for zones, fences, or other metadata
+- simple env-file loading so the connector can run locally or in a container
+
+The shared flow looks like this:
+
+1. Load env-driven configuration.
+2. Connect to the hub transport surface.
+3. Ensure the provider exists through REST.
+4. Optionally upsert trackables or bootstrap fences and zones.
+5. Read upstream data.
+6. Map it to OMLOX payloads.
+7. Publish the payloads.
+8. Retry or reconnect when the upstream source or hub transport fails.
+
+## Running A Connector Locally
+
+The recommended local development path is the shared demo runtime:
+
+1. Start the local stack:
+
+```bash
+connectors/local-hub/start_demo.sh
+```
+
+2. If auth is enabled, fetch a token:
+
+```bash
+connectors/local-hub/fetch_demo_token.sh
+```
+
+3. Create a connector-local env file with the hub URLs, optional token, and any
+   upstream-specific settings.
+4. Run the connector process.
+
+The bundled demos use `HUB_HTTP_URL` for REST bootstrap work and `HUB_WS_URL`
+for WebSocket ingest. MQTT-based connectors would typically use `HUB_HTTP_URL`
+plus `MQTT_BROKER_URL` or equivalent broker settings.
+
+## Choosing A Transport
+
+- [docs/connectors-websocket.md](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/docs/connectors-websocket.md)
+  is the best starting point if you want the same transport flow as the bundled
+  runtime connectors.
+- [docs/connectors-mqtt.md](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/docs/connectors-mqtt.md)
+  explains how to build the same kind of connector on top of the hub's OMLOX
+  MQTT surface.
+
+## Where To Copy From
+
+If you want a fast starting point:
+
+- copy the project structure and env handling style from
+  [`connectors/gtfs/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/gtfs/README.md)
+  or
+  [`connectors/opensky/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/opensky/README.md)
+- use
+  [`connectors/local-hub/README.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/connectors/local-hub/README.md)
+  as the local runtime guide
+- use
+  [`specifications/omlox/websocket.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/specifications/omlox/websocket.md)
+  or
+  [`specifications/omlox/mqtt.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/specifications/omlox/mqtt.md)
+  as the transport source of truth
+
+That is usually enough to get a first connector running quickly.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,20 @@
 # Software Documentation
 
-Reference documentation for hub architecture, configuration, authentication, and RPC behavior.
+Reference documentation for hub architecture, configuration, authentication,
+RPC behavior, and connector development.
+
+Core hub docs:
+
+- [`docs/architecture.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/docs/architecture.md)
+- [`docs/configuration.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/docs/configuration.md)
+- [`docs/auth.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/docs/auth.md)
+- [`docs/rpc.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/docs/rpc.md)
+
+Connector docs:
+
+- [`docs/connectors.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/docs/connectors.md)
+- [`docs/connectors-websocket.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/docs/connectors-websocket.md)
+- [`docs/connectors-mqtt.md`](/Users/jillesvangurp/git/open-rtls/open-rtls-hub/docs/connectors-mqtt.md)
 
 Connector demonstrators live outside the hub runtime under
 [`connectors/`](../connectors).


### PR DESCRIPTION
## Summary
- add an MQTT variant of the GTFS connector that reuses the existing GTFS mapping and REST bootstrap flow
- add MQTT-specific connector helper/config support plus updated GTFS setup docs and env examples
- add connector overview/WebSocket/MQTT docs and point the MQTT guide at the concrete GTFS example

## Why
The repo previously documented MQTT connector development without a bundled MQTT example. This change adds a real GTFS MQTT connector so the MQTT guide can point at an implemented example instead of a documentation-only path.

## Validation
- `just bootstrap`
- `just generate`
- `just check`
- `uv sync --project connectors/gtfs`
- smoke test: `uv run --project connectors/gtfs python connectors/gtfs/connector_mqtt.py --env-file /tmp/gtfs-mqtt.env --once`
- live run against the local demo stack for 190 seconds
  - 13 polls with data
  - 108 MQTT `Location` publishes total
  - per-poll counts: `9,9,9,9,8,8,8,8,8,8,8,8,8`
  - downstream WebSocket observer saw 107 `location_updates` payload items plus one startup/subscription artifact
