### PR TITLE
[codex] Return 404 for unsupported routes before auth

### DIFF
--- a/cmd/hub/main.go
+++ b/cmd/hub/main.go
@@ -301,7 +301,7 @@ func runWithRuntime(ctx context.Context, rt runtimeDeps) error {
 
 	r := chi.NewRouter()
 	r.Use(observability.RequestLogger(logger))
-	r.Use(auth.Middleware(authenticator, cfg.Auth, registry))
+	r.Use(auth.Middleware(authenticator, cfg.Auth, registry, r))
 
 	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/auth/verifier.go
+++ b/internal/auth/verifier.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/formation-res/open-location-hub/internal/config"
 	"github.com/formation-res/open-location-hub/internal/observability"
+	"github.com/go-chi/chi/v5"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -307,13 +308,20 @@ func parseRSAPublicKey(pemText string) (*rsa.PublicKey, error) {
 
 // Middleware authenticates bearer tokens and enforces the configured route
 // authorization registry on incoming HTTP requests.
-func Middleware(authenticator Authenticator, cfg config.AuthConfig, registry *Registry) func(http.Handler) http.Handler {
+func Middleware(authenticator Authenticator, cfg config.AuthConfig, registry *Registry, routes chi.Routes) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 			if !cfg.Enabled || cfg.Mode == "none" || r.URL.Path == "/healthz" || r.URL.Path == "/v2/ws/socket" {
 				next.ServeHTTP(w, r)
 				return
+			}
+			if routes != nil {
+				rctx := chi.NewRouteContext()
+				if !routes.Match(rctx, r.Method, r.URL.Path) {
+					next.ServeHTTP(w, r)
+					return
+				}
 			}
 
 			hdr := strings.TrimSpace(r.Header.Get("Authorization"))

--- a/internal/auth/verifier_test.go
+++ b/internal/auth/verifier_test.go
@@ -6,10 +6,13 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/formation-res/open-location-hub/internal/config"
+	"github.com/go-chi/chi/v5"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -69,6 +72,44 @@ func TestPrincipalFromClaimsExtractsOwnedResources(t *testing.T) {
 
 	if _, ok := principal.OwnedResources["provider_ids"]["provider-1"]; !ok {
 		t.Fatal("expected provider ownership claim")
+	}
+}
+
+func TestMiddlewareSkipsAuthForUnknownPaths(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.AuthConfig{Enabled: true, Mode: "static"}
+	router := chi.NewRouter()
+	router.Use(Middleware(noneAuthenticator{}, cfg, nil, router))
+	router.NotFound(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "missing", http.StatusNotFound)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/missing", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown route, got %d", rec.Code)
+	}
+}
+
+func TestMiddlewareStillAuthenticatesKnownPaths(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.AuthConfig{Enabled: true, Mode: "static"}
+	router := chi.NewRouter()
+	router.Use(Middleware(noneAuthenticator{}, cfg, nil, router))
+	router.Get("/v2/providers", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/providers", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for known protected route without bearer token, got %d", rec.Code)
 	}
 }
 


### PR DESCRIPTION
## What changed
Return `404 Not Found` for unsupported HTTP paths instead of reporting them as authorization failures.

## Why
The auth middleware ran before route resolution, so unknown paths such as legacy or malformed URLs were evaluated against the authorization registry and returned `403 token does not grant access to this endpoint`. That was misleading for integrators and made unsupported endpoints look like credential problems.

## Impact
Unknown routes now fall through to the router's normal `404` handling. Known protected routes still require authentication and authorization as before.

## Root cause
Authorization was being applied to every incoming request before confirming that the path matched any registered route.

## Validation
- `go test ./internal/auth ./cmd/hub`
- `just bootstrap`
- `just generate`
- `just check`
