### PR TITLE
[codex] Complete OMLOX REST endpoint coverage

### DIFF
--- a/internal/httpapi/gen/api.gen.go
+++ b/internal/httpapi/gen/api.gen.go
@@ -585,6 +585,15 @@ type Proximity struct {
 	TimestampSent *time.Time `json:"timestamp_sent,omitempty"`
 }
 
+// ResourceSummary Compact collection summary.
+type ResourceSummary struct {
+	// Count Number of resources currently known to the hub.
+	Count int `json:"count"`
+
+	// Type Resource collection represented by the summary.
+	Type string `json:"type"`
+}
+
 // RpcAvailableMethods Mapping of JSON-RPC method name to currently reachable handler IDs known to the hub.
 type RpcAvailableMethods map[string]RpcAvailableMethodsEntry
 
@@ -776,13 +785,25 @@ type bearerAuthContextKey string
 // PostProviderLocationsJSONBody defines parameters for PostProviderLocations.
 type PostProviderLocationsJSONBody = []Location
 
+// PutProviderLocationsJSONBody defines parameters for PutProviderLocations.
+type PutProviderLocationsJSONBody = []Location
+
 // PostProviderProximitiesJSONBody defines parameters for PostProviderProximities.
 type PostProviderProximitiesJSONBody = []Proximity
+
+// PutProviderProximitiesJSONBody defines parameters for PutProviderProximities.
+type PutProviderProximitiesJSONBody = []Proximity
+
+// PutProviderSensorsJSONBody defines parameters for PutProviderSensors.
+type PutProviderSensorsJSONBody map[string]interface{}
 
 // PutRPC200JSONResponseBody defines parameters for PutRPC.
 type PutRPC200JSONResponseBody struct {
 	union json.RawMessage
 }
+
+// PutZoneTransformJSONBody defines parameters for PutZoneTransform.
+type PutZoneTransformJSONBody map[string]interface{}
 
 // CreateFenceJSONRequestBody defines body for CreateFence for application/json ContentType.
 type CreateFenceJSONRequestBody = FenceWrite
@@ -796,11 +817,26 @@ type CreateProviderJSONRequestBody = LocationProviderWrite
 // PostProviderLocationsJSONRequestBody defines body for PostProviderLocations for application/json ContentType.
 type PostProviderLocationsJSONRequestBody = PostProviderLocationsJSONBody
 
+// PutProviderLocationsJSONRequestBody defines body for PutProviderLocations for application/json ContentType.
+type PutProviderLocationsJSONRequestBody = PutProviderLocationsJSONBody
+
 // PostProviderProximitiesJSONRequestBody defines body for PostProviderProximities for application/json ContentType.
 type PostProviderProximitiesJSONRequestBody = PostProviderProximitiesJSONBody
 
+// PutProviderProximitiesJSONRequestBody defines body for PutProviderProximities for application/json ContentType.
+type PutProviderProximitiesJSONRequestBody = PutProviderProximitiesJSONBody
+
 // UpdateProviderJSONRequestBody defines body for UpdateProvider for application/json ContentType.
 type UpdateProviderJSONRequestBody = LocationProviderWrite
+
+// PutProviderLocationJSONRequestBody defines body for PutProviderLocation for application/json ContentType.
+type PutProviderLocationJSONRequestBody = Location
+
+// PutProviderProximityJSONRequestBody defines body for PutProviderProximity for application/json ContentType.
+type PutProviderProximityJSONRequestBody = Proximity
+
+// PutProviderSensorsJSONRequestBody defines body for PutProviderSensors for application/json ContentType.
+type PutProviderSensorsJSONRequestBody PutProviderSensorsJSONBody
 
 // PutRPCJSONRequestBody defines body for PutRPC for application/json ContentType.
 type PutRPCJSONRequestBody = JsonRpcRequest
@@ -816,6 +852,9 @@ type CreateZoneJSONRequestBody = ZoneWrite
 
 // UpdateZoneJSONRequestBody defines body for UpdateZone for application/json ContentType.
 type UpdateZoneJSONRequestBody = ZoneWrite
+
+// PutZoneTransformJSONRequestBody defines body for PutZoneTransform for application/json ContentType.
+type PutZoneTransformJSONRequestBody PutZoneTransformJSONBody
 
 // Getter for additional properties for JsonRpcRequest_Params. Returns the specified
 // element and whether it was found
@@ -1506,12 +1545,18 @@ func (t *PutRPC200JSONResponseBody) UnmarshalJSON(b []byte) error {
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// Delete all fences
+	// (DELETE /v2/fences)
+	DeleteFences(w http.ResponseWriter, r *http.Request)
 	// List fences
 	// (GET /v2/fences)
 	ListFences(w http.ResponseWriter, r *http.Request)
 	// Create a fence
 	// (POST /v2/fences)
 	CreateFence(w http.ResponseWriter, r *http.Request)
+	// Get fence summary
+	// (GET /v2/fences/summary)
+	GetFencesSummary(w http.ResponseWriter, r *http.Request)
 	// Delete a fence
 	// (DELETE /v2/fences/{fenceId})
 	DeleteFence(w http.ResponseWriter, r *http.Request, fenceId FenceId)
@@ -1521,18 +1566,42 @@ type ServerInterface interface {
 	// Update a fence
 	// (PUT /v2/fences/{fenceId})
 	UpdateFence(w http.ResponseWriter, r *http.Request, fenceId FenceId)
+	// Get fence locations
+	// (GET /v2/fences/{fenceId}/locations)
+	GetFenceLocations(w http.ResponseWriter, r *http.Request, fenceId FenceId)
+	// Get fence providers
+	// (GET /v2/fences/{fenceId}/providers)
+	GetFenceProviders(w http.ResponseWriter, r *http.Request, fenceId FenceId)
+	// Delete all providers
+	// (DELETE /v2/providers)
+	DeleteProviders(w http.ResponseWriter, r *http.Request)
 	// List providers
 	// (GET /v2/providers)
 	ListProviders(w http.ResponseWriter, r *http.Request)
 	// Create a provider
 	// (POST /v2/providers)
 	CreateProvider(w http.ResponseWriter, r *http.Request)
+	// Delete provider locations
+	// (DELETE /v2/providers/locations)
+	DeleteProviderLocations(w http.ResponseWriter, r *http.Request)
+	// Get provider locations
+	// (GET /v2/providers/locations)
+	GetProviderLocations(w http.ResponseWriter, r *http.Request)
 	// Ingest locations
 	// (POST /v2/providers/locations)
 	PostProviderLocations(w http.ResponseWriter, r *http.Request)
+	// Replace provider locations
+	// (PUT /v2/providers/locations)
+	PutProviderLocations(w http.ResponseWriter, r *http.Request)
 	// Ingest proximities
 	// (POST /v2/providers/proximities)
 	PostProviderProximities(w http.ResponseWriter, r *http.Request)
+	// Replace provider proximities
+	// (PUT /v2/providers/proximities)
+	PutProviderProximities(w http.ResponseWriter, r *http.Request)
+	// Get provider summary
+	// (GET /v2/providers/summary)
+	GetProvidersSummary(w http.ResponseWriter, r *http.Request)
 	// Delete a provider
 	// (DELETE /v2/providers/{providerId})
 	DeleteProvider(w http.ResponseWriter, r *http.Request, providerId ProviderId)
@@ -1542,18 +1611,48 @@ type ServerInterface interface {
 	// Update a provider
 	// (PUT /v2/providers/{providerId})
 	UpdateProvider(w http.ResponseWriter, r *http.Request, providerId ProviderId)
+	// Get provider fences
+	// (GET /v2/providers/{providerId}/fences)
+	GetProviderFences(w http.ResponseWriter, r *http.Request, providerId ProviderId)
+	// Delete provider location
+	// (DELETE /v2/providers/{providerId}/location)
+	DeleteProviderLocation(w http.ResponseWriter, r *http.Request, providerId ProviderId)
+	// Get provider location
+	// (GET /v2/providers/{providerId}/location)
+	GetProviderLocation(w http.ResponseWriter, r *http.Request, providerId ProviderId)
+	// Update provider location
+	// (PUT /v2/providers/{providerId}/location)
+	PutProviderLocation(w http.ResponseWriter, r *http.Request, providerId ProviderId)
+	// Update provider proximity
+	// (PUT /v2/providers/{providerId}/proximity)
+	PutProviderProximity(w http.ResponseWriter, r *http.Request, providerId ProviderId)
+	// Get provider sensors
+	// (GET /v2/providers/{providerId}/sensors)
+	GetProviderSensors(w http.ResponseWriter, r *http.Request, providerId ProviderId)
+	// Update provider sensors
+	// (PUT /v2/providers/{providerId}/sensors)
+	PutProviderSensors(w http.ResponseWriter, r *http.Request, providerId ProviderId)
 	// Invoke JSON-RPC
 	// (PUT /v2/rpc)
 	PutRPC(w http.ResponseWriter, r *http.Request)
 	// List available RPC methods
 	// (GET /v2/rpc/available)
 	GetRPCAvailable(w http.ResponseWriter, r *http.Request)
+	// Delete all trackables
+	// (DELETE /v2/trackables)
+	DeleteTrackables(w http.ResponseWriter, r *http.Request)
 	// List trackables
 	// (GET /v2/trackables)
 	ListTrackables(w http.ResponseWriter, r *http.Request)
 	// Create a trackable
 	// (POST /v2/trackables)
 	CreateTrackable(w http.ResponseWriter, r *http.Request)
+	// List trackable motions
+	// (GET /v2/trackables/motions)
+	GetTrackableMotions(w http.ResponseWriter, r *http.Request)
+	// Get trackable summary
+	// (GET /v2/trackables/summary)
+	GetTrackablesSummary(w http.ResponseWriter, r *http.Request)
 	// Delete a trackable
 	// (DELETE /v2/trackables/{trackableId})
 	DeleteTrackable(w http.ResponseWriter, r *http.Request, trackableId TrackableId)
@@ -1563,12 +1662,36 @@ type ServerInterface interface {
 	// Update a trackable
 	// (PUT /v2/trackables/{trackableId})
 	UpdateTrackable(w http.ResponseWriter, r *http.Request, trackableId TrackableId)
+	// Get trackable fences
+	// (GET /v2/trackables/{trackableId}/fences)
+	GetTrackableFences(w http.ResponseWriter, r *http.Request, trackableId TrackableId)
+	// Get trackable location
+	// (GET /v2/trackables/{trackableId}/location)
+	GetTrackableLocation(w http.ResponseWriter, r *http.Request, trackableId TrackableId)
+	// Get trackable locations
+	// (GET /v2/trackables/{trackableId}/locations)
+	GetTrackableLocations(w http.ResponseWriter, r *http.Request, trackableId TrackableId)
+	// Get trackable motion
+	// (GET /v2/trackables/{trackableId}/motion)
+	GetTrackableMotion(w http.ResponseWriter, r *http.Request, trackableId TrackableId)
+	// Get trackable providers
+	// (GET /v2/trackables/{trackableId}/providers)
+	GetTrackableProviders(w http.ResponseWriter, r *http.Request, trackableId TrackableId)
+	// Get trackable sensors
+	// (GET /v2/trackables/{trackableId}/sensors)
+	GetTrackableSensors(w http.ResponseWriter, r *http.Request, trackableId TrackableId)
+	// Delete all zones
+	// (DELETE /v2/zones)
+	DeleteZones(w http.ResponseWriter, r *http.Request)
 	// List zones
 	// (GET /v2/zones)
 	ListZones(w http.ResponseWriter, r *http.Request)
 	// Create a zone
 	// (POST /v2/zones)
 	CreateZone(w http.ResponseWriter, r *http.Request)
+	// Get zone summary
+	// (GET /v2/zones/summary)
+	GetZonesSummary(w http.ResponseWriter, r *http.Request)
 	// Delete a zone
 	// (DELETE /v2/zones/{zoneId})
 	DeleteZone(w http.ResponseWriter, r *http.Request, zoneId ZoneId)
@@ -1578,11 +1701,23 @@ type ServerInterface interface {
 	// Update a zone
 	// (PUT /v2/zones/{zoneId})
 	UpdateZone(w http.ResponseWriter, r *http.Request, zoneId ZoneId)
+	// Create fence from zone
+	// (GET /v2/zones/{zoneId}/createfence)
+	GetZoneCreateFence(w http.ResponseWriter, r *http.Request, zoneId ZoneId)
+	// Update zone transform
+	// (PUT /v2/zones/{zoneId}/transform)
+	PutZoneTransform(w http.ResponseWriter, r *http.Request, zoneId ZoneId)
 }
 
 // Unimplemented server implementation that returns http.StatusNotImplemented for each endpoint.
 
 type Unimplemented struct{}
+
+// Delete all fences
+// (DELETE /v2/fences)
+func (_ Unimplemented) DeleteFences(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
 
 // List fences
 // (GET /v2/fences)
@@ -1593,6 +1728,12 @@ func (_ Unimplemented) ListFences(w http.ResponseWriter, r *http.Request) {
 // Create a fence
 // (POST /v2/fences)
 func (_ Unimplemented) CreateFence(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get fence summary
+// (GET /v2/fences/summary)
+func (_ Unimplemented) GetFencesSummary(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1614,6 +1755,24 @@ func (_ Unimplemented) UpdateFence(w http.ResponseWriter, r *http.Request, fence
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Get fence locations
+// (GET /v2/fences/{fenceId}/locations)
+func (_ Unimplemented) GetFenceLocations(w http.ResponseWriter, r *http.Request, fenceId FenceId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get fence providers
+// (GET /v2/fences/{fenceId}/providers)
+func (_ Unimplemented) GetFenceProviders(w http.ResponseWriter, r *http.Request, fenceId FenceId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Delete all providers
+// (DELETE /v2/providers)
+func (_ Unimplemented) DeleteProviders(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // List providers
 // (GET /v2/providers)
 func (_ Unimplemented) ListProviders(w http.ResponseWriter, r *http.Request) {
@@ -1626,15 +1785,45 @@ func (_ Unimplemented) CreateProvider(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Delete provider locations
+// (DELETE /v2/providers/locations)
+func (_ Unimplemented) DeleteProviderLocations(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get provider locations
+// (GET /v2/providers/locations)
+func (_ Unimplemented) GetProviderLocations(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // Ingest locations
 // (POST /v2/providers/locations)
 func (_ Unimplemented) PostProviderLocations(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Replace provider locations
+// (PUT /v2/providers/locations)
+func (_ Unimplemented) PutProviderLocations(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // Ingest proximities
 // (POST /v2/providers/proximities)
 func (_ Unimplemented) PostProviderProximities(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Replace provider proximities
+// (PUT /v2/providers/proximities)
+func (_ Unimplemented) PutProviderProximities(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get provider summary
+// (GET /v2/providers/summary)
+func (_ Unimplemented) GetProvidersSummary(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1656,6 +1845,48 @@ func (_ Unimplemented) UpdateProvider(w http.ResponseWriter, r *http.Request, pr
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Get provider fences
+// (GET /v2/providers/{providerId}/fences)
+func (_ Unimplemented) GetProviderFences(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Delete provider location
+// (DELETE /v2/providers/{providerId}/location)
+func (_ Unimplemented) DeleteProviderLocation(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get provider location
+// (GET /v2/providers/{providerId}/location)
+func (_ Unimplemented) GetProviderLocation(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Update provider location
+// (PUT /v2/providers/{providerId}/location)
+func (_ Unimplemented) PutProviderLocation(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Update provider proximity
+// (PUT /v2/providers/{providerId}/proximity)
+func (_ Unimplemented) PutProviderProximity(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get provider sensors
+// (GET /v2/providers/{providerId}/sensors)
+func (_ Unimplemented) GetProviderSensors(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Update provider sensors
+// (PUT /v2/providers/{providerId}/sensors)
+func (_ Unimplemented) PutProviderSensors(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // Invoke JSON-RPC
 // (PUT /v2/rpc)
 func (_ Unimplemented) PutRPC(w http.ResponseWriter, r *http.Request) {
@@ -1668,6 +1899,12 @@ func (_ Unimplemented) GetRPCAvailable(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Delete all trackables
+// (DELETE /v2/trackables)
+func (_ Unimplemented) DeleteTrackables(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // List trackables
 // (GET /v2/trackables)
 func (_ Unimplemented) ListTrackables(w http.ResponseWriter, r *http.Request) {
@@ -1677,6 +1914,18 @@ func (_ Unimplemented) ListTrackables(w http.ResponseWriter, r *http.Request) {
 // Create a trackable
 // (POST /v2/trackables)
 func (_ Unimplemented) CreateTrackable(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List trackable motions
+// (GET /v2/trackables/motions)
+func (_ Unimplemented) GetTrackableMotions(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get trackable summary
+// (GET /v2/trackables/summary)
+func (_ Unimplemented) GetTrackablesSummary(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1698,6 +1947,48 @@ func (_ Unimplemented) UpdateTrackable(w http.ResponseWriter, r *http.Request, t
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Get trackable fences
+// (GET /v2/trackables/{trackableId}/fences)
+func (_ Unimplemented) GetTrackableFences(w http.ResponseWriter, r *http.Request, trackableId TrackableId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get trackable location
+// (GET /v2/trackables/{trackableId}/location)
+func (_ Unimplemented) GetTrackableLocation(w http.ResponseWriter, r *http.Request, trackableId TrackableId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get trackable locations
+// (GET /v2/trackables/{trackableId}/locations)
+func (_ Unimplemented) GetTrackableLocations(w http.ResponseWriter, r *http.Request, trackableId TrackableId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get trackable motion
+// (GET /v2/trackables/{trackableId}/motion)
+func (_ Unimplemented) GetTrackableMotion(w http.ResponseWriter, r *http.Request, trackableId TrackableId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get trackable providers
+// (GET /v2/trackables/{trackableId}/providers)
+func (_ Unimplemented) GetTrackableProviders(w http.ResponseWriter, r *http.Request, trackableId TrackableId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get trackable sensors
+// (GET /v2/trackables/{trackableId}/sensors)
+func (_ Unimplemented) GetTrackableSensors(w http.ResponseWriter, r *http.Request, trackableId TrackableId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Delete all zones
+// (DELETE /v2/zones)
+func (_ Unimplemented) DeleteZones(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // List zones
 // (GET /v2/zones)
 func (_ Unimplemented) ListZones(w http.ResponseWriter, r *http.Request) {
@@ -1707,6 +1998,12 @@ func (_ Unimplemented) ListZones(w http.ResponseWriter, r *http.Request) {
 // Create a zone
 // (POST /v2/zones)
 func (_ Unimplemented) CreateZone(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get zone summary
+// (GET /v2/zones/summary)
+func (_ Unimplemented) GetZonesSummary(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1728,6 +2025,18 @@ func (_ Unimplemented) UpdateZone(w http.ResponseWriter, r *http.Request, zoneId
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Create fence from zone
+// (GET /v2/zones/{zoneId}/createfence)
+func (_ Unimplemented) GetZoneCreateFence(w http.ResponseWriter, r *http.Request, zoneId ZoneId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Update zone transform
+// (PUT /v2/zones/{zoneId}/transform)
+func (_ Unimplemented) PutZoneTransform(w http.ResponseWriter, r *http.Request, zoneId ZoneId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // ServerInterfaceWrapper converts contexts to parameters.
 type ServerInterfaceWrapper struct {
 	Handler            ServerInterface
@@ -1736,6 +2045,26 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// DeleteFences operation middleware
+func (siw *ServerInterfaceWrapper) DeleteFences(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteFences(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // ListFences operation middleware
 func (siw *ServerInterfaceWrapper) ListFences(w http.ResponseWriter, r *http.Request) {
@@ -1768,6 +2097,26 @@ func (siw *ServerInterfaceWrapper) CreateFence(w http.ResponseWriter, r *http.Re
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.CreateFence(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetFencesSummary operation middleware
+func (siw *ServerInterfaceWrapper) GetFencesSummary(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetFencesSummary(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1873,6 +2222,90 @@ func (siw *ServerInterfaceWrapper) UpdateFence(w http.ResponseWriter, r *http.Re
 	handler.ServeHTTP(w, r)
 }
 
+// GetFenceLocations operation middleware
+func (siw *ServerInterfaceWrapper) GetFenceLocations(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "fenceId" -------------
+	var fenceId FenceId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "fenceId", chi.URLParam(r, "fenceId"), &fenceId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "fenceId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetFenceLocations(w, r, fenceId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetFenceProviders operation middleware
+func (siw *ServerInterfaceWrapper) GetFenceProviders(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "fenceId" -------------
+	var fenceId FenceId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "fenceId", chi.URLParam(r, "fenceId"), &fenceId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "fenceId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetFenceProviders(w, r, fenceId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteProviders operation middleware
+func (siw *ServerInterfaceWrapper) DeleteProviders(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteProviders(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListProviders operation middleware
 func (siw *ServerInterfaceWrapper) ListProviders(w http.ResponseWriter, r *http.Request) {
 
@@ -1913,6 +2346,46 @@ func (siw *ServerInterfaceWrapper) CreateProvider(w http.ResponseWriter, r *http
 	handler.ServeHTTP(w, r)
 }
 
+// DeleteProviderLocations operation middleware
+func (siw *ServerInterfaceWrapper) DeleteProviderLocations(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteProviderLocations(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetProviderLocations operation middleware
+func (siw *ServerInterfaceWrapper) GetProviderLocations(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProviderLocations(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // PostProviderLocations operation middleware
 func (siw *ServerInterfaceWrapper) PostProviderLocations(w http.ResponseWriter, r *http.Request) {
 
@@ -1933,6 +2406,26 @@ func (siw *ServerInterfaceWrapper) PostProviderLocations(w http.ResponseWriter, 
 	handler.ServeHTTP(w, r)
 }
 
+// PutProviderLocations operation middleware
+func (siw *ServerInterfaceWrapper) PutProviderLocations(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PutProviderLocations(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // PostProviderProximities operation middleware
 func (siw *ServerInterfaceWrapper) PostProviderProximities(w http.ResponseWriter, r *http.Request) {
 
@@ -1944,6 +2437,46 @@ func (siw *ServerInterfaceWrapper) PostProviderProximities(w http.ResponseWriter
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.PostProviderProximities(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PutProviderProximities operation middleware
+func (siw *ServerInterfaceWrapper) PutProviderProximities(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PutProviderProximities(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetProvidersSummary operation middleware
+func (siw *ServerInterfaceWrapper) GetProvidersSummary(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProvidersSummary(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2049,6 +2582,230 @@ func (siw *ServerInterfaceWrapper) UpdateProvider(w http.ResponseWriter, r *http
 	handler.ServeHTTP(w, r)
 }
 
+// GetProviderFences operation middleware
+func (siw *ServerInterfaceWrapper) GetProviderFences(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "providerId" -------------
+	var providerId ProviderId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "providerId", chi.URLParam(r, "providerId"), &providerId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "providerId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProviderFences(w, r, providerId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteProviderLocation operation middleware
+func (siw *ServerInterfaceWrapper) DeleteProviderLocation(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "providerId" -------------
+	var providerId ProviderId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "providerId", chi.URLParam(r, "providerId"), &providerId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "providerId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteProviderLocation(w, r, providerId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetProviderLocation operation middleware
+func (siw *ServerInterfaceWrapper) GetProviderLocation(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "providerId" -------------
+	var providerId ProviderId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "providerId", chi.URLParam(r, "providerId"), &providerId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "providerId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProviderLocation(w, r, providerId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PutProviderLocation operation middleware
+func (siw *ServerInterfaceWrapper) PutProviderLocation(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "providerId" -------------
+	var providerId ProviderId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "providerId", chi.URLParam(r, "providerId"), &providerId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "providerId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PutProviderLocation(w, r, providerId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PutProviderProximity operation middleware
+func (siw *ServerInterfaceWrapper) PutProviderProximity(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "providerId" -------------
+	var providerId ProviderId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "providerId", chi.URLParam(r, "providerId"), &providerId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "providerId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PutProviderProximity(w, r, providerId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetProviderSensors operation middleware
+func (siw *ServerInterfaceWrapper) GetProviderSensors(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "providerId" -------------
+	var providerId ProviderId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "providerId", chi.URLParam(r, "providerId"), &providerId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "providerId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProviderSensors(w, r, providerId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PutProviderSensors operation middleware
+func (siw *ServerInterfaceWrapper) PutProviderSensors(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "providerId" -------------
+	var providerId ProviderId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "providerId", chi.URLParam(r, "providerId"), &providerId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "providerId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PutProviderSensors(w, r, providerId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // PutRPC operation middleware
 func (siw *ServerInterfaceWrapper) PutRPC(w http.ResponseWriter, r *http.Request) {
 
@@ -2089,6 +2846,26 @@ func (siw *ServerInterfaceWrapper) GetRPCAvailable(w http.ResponseWriter, r *htt
 	handler.ServeHTTP(w, r)
 }
 
+// DeleteTrackables operation middleware
+func (siw *ServerInterfaceWrapper) DeleteTrackables(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteTrackables(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListTrackables operation middleware
 func (siw *ServerInterfaceWrapper) ListTrackables(w http.ResponseWriter, r *http.Request) {
 
@@ -2120,6 +2897,46 @@ func (siw *ServerInterfaceWrapper) CreateTrackable(w http.ResponseWriter, r *htt
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.CreateTrackable(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetTrackableMotions operation middleware
+func (siw *ServerInterfaceWrapper) GetTrackableMotions(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetTrackableMotions(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetTrackablesSummary operation middleware
+func (siw *ServerInterfaceWrapper) GetTrackablesSummary(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetTrackablesSummary(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2225,6 +3042,218 @@ func (siw *ServerInterfaceWrapper) UpdateTrackable(w http.ResponseWriter, r *htt
 	handler.ServeHTTP(w, r)
 }
 
+// GetTrackableFences operation middleware
+func (siw *ServerInterfaceWrapper) GetTrackableFences(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "trackableId" -------------
+	var trackableId TrackableId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "trackableId", chi.URLParam(r, "trackableId"), &trackableId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "trackableId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetTrackableFences(w, r, trackableId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetTrackableLocation operation middleware
+func (siw *ServerInterfaceWrapper) GetTrackableLocation(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "trackableId" -------------
+	var trackableId TrackableId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "trackableId", chi.URLParam(r, "trackableId"), &trackableId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "trackableId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetTrackableLocation(w, r, trackableId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetTrackableLocations operation middleware
+func (siw *ServerInterfaceWrapper) GetTrackableLocations(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "trackableId" -------------
+	var trackableId TrackableId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "trackableId", chi.URLParam(r, "trackableId"), &trackableId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "trackableId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetTrackableLocations(w, r, trackableId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetTrackableMotion operation middleware
+func (siw *ServerInterfaceWrapper) GetTrackableMotion(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "trackableId" -------------
+	var trackableId TrackableId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "trackableId", chi.URLParam(r, "trackableId"), &trackableId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "trackableId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetTrackableMotion(w, r, trackableId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetTrackableProviders operation middleware
+func (siw *ServerInterfaceWrapper) GetTrackableProviders(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "trackableId" -------------
+	var trackableId TrackableId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "trackableId", chi.URLParam(r, "trackableId"), &trackableId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "trackableId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetTrackableProviders(w, r, trackableId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetTrackableSensors operation middleware
+func (siw *ServerInterfaceWrapper) GetTrackableSensors(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "trackableId" -------------
+	var trackableId TrackableId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "trackableId", chi.URLParam(r, "trackableId"), &trackableId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "trackableId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetTrackableSensors(w, r, trackableId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteZones operation middleware
+func (siw *ServerInterfaceWrapper) DeleteZones(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteZones(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListZones operation middleware
 func (siw *ServerInterfaceWrapper) ListZones(w http.ResponseWriter, r *http.Request) {
 
@@ -2256,6 +3285,26 @@ func (siw *ServerInterfaceWrapper) CreateZone(w http.ResponseWriter, r *http.Req
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.CreateZone(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetZonesSummary operation middleware
+func (siw *ServerInterfaceWrapper) GetZonesSummary(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetZonesSummary(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2352,6 +3401,70 @@ func (siw *ServerInterfaceWrapper) UpdateZone(w http.ResponseWriter, r *http.Req
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UpdateZone(w, r, zoneId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetZoneCreateFence operation middleware
+func (siw *ServerInterfaceWrapper) GetZoneCreateFence(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "zoneId" -------------
+	var zoneId ZoneId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "zoneId", chi.URLParam(r, "zoneId"), &zoneId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "zoneId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetZoneCreateFence(w, r, zoneId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PutZoneTransform operation middleware
+func (siw *ServerInterfaceWrapper) PutZoneTransform(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "zoneId" -------------
+	var zoneId ZoneId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "zoneId", chi.URLParam(r, "zoneId"), &zoneId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "zoneId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PutZoneTransform(w, r, zoneId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2475,10 +3588,16 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	}
 
 	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/v2/fences", wrapper.DeleteFences)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v2/fences", wrapper.ListFences)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v2/fences", wrapper.CreateFence)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/fences/summary", wrapper.GetFencesSummary)
 	})
 	r.Group(func(r chi.Router) {
 		r.Delete(options.BaseURL+"/v2/fences/{fenceId}", wrapper.DeleteFence)
@@ -2490,16 +3609,40 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Put(options.BaseURL+"/v2/fences/{fenceId}", wrapper.UpdateFence)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/fences/{fenceId}/locations", wrapper.GetFenceLocations)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/fences/{fenceId}/providers", wrapper.GetFenceProviders)
+	})
+	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/v2/providers", wrapper.DeleteProviders)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v2/providers", wrapper.ListProviders)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v2/providers", wrapper.CreateProvider)
 	})
 	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/v2/providers/locations", wrapper.DeleteProviderLocations)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/providers/locations", wrapper.GetProviderLocations)
+	})
+	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v2/providers/locations", wrapper.PostProviderLocations)
 	})
 	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/v2/providers/locations", wrapper.PutProviderLocations)
+	})
+	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v2/providers/proximities", wrapper.PostProviderProximities)
+	})
+	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/v2/providers/proximities", wrapper.PutProviderProximities)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/providers/summary", wrapper.GetProvidersSummary)
 	})
 	r.Group(func(r chi.Router) {
 		r.Delete(options.BaseURL+"/v2/providers/{providerId}", wrapper.DeleteProvider)
@@ -2511,16 +3654,46 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Put(options.BaseURL+"/v2/providers/{providerId}", wrapper.UpdateProvider)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/providers/{providerId}/fences", wrapper.GetProviderFences)
+	})
+	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/v2/providers/{providerId}/location", wrapper.DeleteProviderLocation)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/providers/{providerId}/location", wrapper.GetProviderLocation)
+	})
+	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/v2/providers/{providerId}/location", wrapper.PutProviderLocation)
+	})
+	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/v2/providers/{providerId}/proximity", wrapper.PutProviderProximity)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/providers/{providerId}/sensors", wrapper.GetProviderSensors)
+	})
+	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/v2/providers/{providerId}/sensors", wrapper.PutProviderSensors)
+	})
+	r.Group(func(r chi.Router) {
 		r.Put(options.BaseURL+"/v2/rpc", wrapper.PutRPC)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v2/rpc/available", wrapper.GetRPCAvailable)
 	})
 	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/v2/trackables", wrapper.DeleteTrackables)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v2/trackables", wrapper.ListTrackables)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v2/trackables", wrapper.CreateTrackable)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/trackables/motions", wrapper.GetTrackableMotions)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/trackables/summary", wrapper.GetTrackablesSummary)
 	})
 	r.Group(func(r chi.Router) {
 		r.Delete(options.BaseURL+"/v2/trackables/{trackableId}", wrapper.DeleteTrackable)
@@ -2532,10 +3705,34 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Put(options.BaseURL+"/v2/trackables/{trackableId}", wrapper.UpdateTrackable)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/trackables/{trackableId}/fences", wrapper.GetTrackableFences)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/trackables/{trackableId}/location", wrapper.GetTrackableLocation)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/trackables/{trackableId}/locations", wrapper.GetTrackableLocations)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/trackables/{trackableId}/motion", wrapper.GetTrackableMotion)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/trackables/{trackableId}/providers", wrapper.GetTrackableProviders)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/trackables/{trackableId}/sensors", wrapper.GetTrackableSensors)
+	})
+	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/v2/zones", wrapper.DeleteZones)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v2/zones", wrapper.ListZones)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v2/zones", wrapper.CreateZone)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/zones/summary", wrapper.GetZonesSummary)
 	})
 	r.Group(func(r chi.Router) {
 		r.Delete(options.BaseURL+"/v2/zones/{zoneId}", wrapper.DeleteZone)
@@ -2545,6 +3742,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Put(options.BaseURL+"/v2/zones/{zoneId}", wrapper.UpdateZone)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v2/zones/{zoneId}/createfence", wrapper.GetZoneCreateFence)
+	})
+	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/v2/zones/{zoneId}/transform", wrapper.PutZoneTransform)
 	})
 
 	return r
@@ -2557,6 +3760,49 @@ type ForbiddenJSONResponse ErrorResponse
 type NotFoundJSONResponse ErrorResponse
 
 type UnauthorizedJSONResponse ErrorResponse
+
+type DeleteFencesRequestObject struct {
+}
+
+type DeleteFencesResponseObject interface {
+	VisitDeleteFencesResponse(w http.ResponseWriter) error
+}
+
+type DeleteFences204Response struct {
+}
+
+func (response DeleteFences204Response) VisitDeleteFencesResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
+}
+
+type DeleteFences401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response DeleteFences401JSONResponse) VisitDeleteFencesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteFences403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response DeleteFences403JSONResponse) VisitDeleteFencesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
 
 type ListFencesRequestObject struct {
 }
@@ -2660,6 +3906,55 @@ func (response CreateFence401JSONResponse) VisitCreateFenceResponse(w http.Respo
 type CreateFence403JSONResponse struct{ ForbiddenJSONResponse }
 
 func (response CreateFence403JSONResponse) VisitCreateFenceResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetFencesSummaryRequestObject struct {
+}
+
+type GetFencesSummaryResponseObject interface {
+	VisitGetFencesSummaryResponse(w http.ResponseWriter) error
+}
+
+type GetFencesSummary200JSONResponse ResourceSummary
+
+func (response GetFencesSummary200JSONResponse) VisitGetFencesSummaryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetFencesSummary401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetFencesSummary401JSONResponse) VisitGetFencesSummaryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetFencesSummary403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetFencesSummary403JSONResponse) VisitGetFencesSummaryResponse(w http.ResponseWriter) error {
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(response); err != nil {
@@ -2872,6 +4167,177 @@ func (response UpdateFence404JSONResponse) VisitUpdateFenceResponse(w http.Respo
 	return err
 }
 
+type GetFenceLocationsRequestObject struct {
+	FenceId FenceId `json:"fenceId"`
+}
+
+type GetFenceLocationsResponseObject interface {
+	VisitGetFenceLocationsResponse(w http.ResponseWriter) error
+}
+
+type GetFenceLocations200JSONResponse []Location
+
+func (response GetFenceLocations200JSONResponse) VisitGetFenceLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetFenceLocations401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetFenceLocations401JSONResponse) VisitGetFenceLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetFenceLocations403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetFenceLocations403JSONResponse) VisitGetFenceLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetFenceLocations404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetFenceLocations404JSONResponse) VisitGetFenceLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetFenceProvidersRequestObject struct {
+	FenceId FenceId `json:"fenceId"`
+}
+
+type GetFenceProvidersResponseObject interface {
+	VisitGetFenceProvidersResponse(w http.ResponseWriter) error
+}
+
+type GetFenceProviders200JSONResponse []LocationProvider
+
+func (response GetFenceProviders200JSONResponse) VisitGetFenceProvidersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetFenceProviders401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetFenceProviders401JSONResponse) VisitGetFenceProvidersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetFenceProviders403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetFenceProviders403JSONResponse) VisitGetFenceProvidersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetFenceProviders404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetFenceProviders404JSONResponse) VisitGetFenceProvidersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteProvidersRequestObject struct {
+}
+
+type DeleteProvidersResponseObject interface {
+	VisitDeleteProvidersResponse(w http.ResponseWriter) error
+}
+
+type DeleteProviders204Response struct {
+}
+
+func (response DeleteProviders204Response) VisitDeleteProvidersResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
+}
+
+type DeleteProviders401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response DeleteProviders401JSONResponse) VisitDeleteProvidersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteProviders403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response DeleteProviders403JSONResponse) VisitDeleteProvidersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 type ListProvidersRequestObject struct {
 }
 
@@ -2985,6 +4451,98 @@ func (response CreateProvider403JSONResponse) VisitCreateProviderResponse(w http
 	return err
 }
 
+type DeleteProviderLocationsRequestObject struct {
+}
+
+type DeleteProviderLocationsResponseObject interface {
+	VisitDeleteProviderLocationsResponse(w http.ResponseWriter) error
+}
+
+type DeleteProviderLocations204Response struct {
+}
+
+func (response DeleteProviderLocations204Response) VisitDeleteProviderLocationsResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
+}
+
+type DeleteProviderLocations401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response DeleteProviderLocations401JSONResponse) VisitDeleteProviderLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteProviderLocations403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response DeleteProviderLocations403JSONResponse) VisitDeleteProviderLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderLocationsRequestObject struct {
+}
+
+type GetProviderLocationsResponseObject interface {
+	VisitGetProviderLocationsResponse(w http.ResponseWriter) error
+}
+
+type GetProviderLocations200JSONResponse []Location
+
+func (response GetProviderLocations200JSONResponse) VisitGetProviderLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderLocations401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetProviderLocations401JSONResponse) VisitGetProviderLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderLocations403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetProviderLocations403JSONResponse) VisitGetProviderLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 type PostProviderLocationsRequestObject struct {
 	Body *PostProviderLocationsJSONRequestBody
 }
@@ -3043,6 +4601,64 @@ func (response PostProviderLocations403JSONResponse) VisitPostProviderLocationsR
 	return err
 }
 
+type PutProviderLocationsRequestObject struct {
+	Body *PutProviderLocationsJSONRequestBody
+}
+
+type PutProviderLocationsResponseObject interface {
+	VisitPutProviderLocationsResponse(w http.ResponseWriter) error
+}
+
+type PutProviderLocations202Response struct {
+}
+
+func (response PutProviderLocations202Response) VisitPutProviderLocationsResponse(w http.ResponseWriter) error {
+	w.WriteHeader(202)
+	return nil
+}
+
+type PutProviderLocations400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response PutProviderLocations400JSONResponse) VisitPutProviderLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderLocations401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response PutProviderLocations401JSONResponse) VisitPutProviderLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderLocations403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response PutProviderLocations403JSONResponse) VisitPutProviderLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 type PostProviderProximitiesRequestObject struct {
 	Body *PostProviderProximitiesJSONRequestBody
 }
@@ -3090,6 +4706,113 @@ func (response PostProviderProximities401JSONResponse) VisitPostProviderProximit
 type PostProviderProximities403JSONResponse struct{ ForbiddenJSONResponse }
 
 func (response PostProviderProximities403JSONResponse) VisitPostProviderProximitiesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderProximitiesRequestObject struct {
+	Body *PutProviderProximitiesJSONRequestBody
+}
+
+type PutProviderProximitiesResponseObject interface {
+	VisitPutProviderProximitiesResponse(w http.ResponseWriter) error
+}
+
+type PutProviderProximities202Response struct {
+}
+
+func (response PutProviderProximities202Response) VisitPutProviderProximitiesResponse(w http.ResponseWriter) error {
+	w.WriteHeader(202)
+	return nil
+}
+
+type PutProviderProximities400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response PutProviderProximities400JSONResponse) VisitPutProviderProximitiesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderProximities401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response PutProviderProximities401JSONResponse) VisitPutProviderProximitiesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderProximities403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response PutProviderProximities403JSONResponse) VisitPutProviderProximitiesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProvidersSummaryRequestObject struct {
+}
+
+type GetProvidersSummaryResponseObject interface {
+	VisitGetProvidersSummaryResponse(w http.ResponseWriter) error
+}
+
+type GetProvidersSummary200JSONResponse ResourceSummary
+
+func (response GetProvidersSummary200JSONResponse) VisitGetProvidersSummaryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProvidersSummary401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetProvidersSummary401JSONResponse) VisitGetProvidersSummaryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProvidersSummary403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetProvidersSummary403JSONResponse) VisitGetProvidersSummaryResponse(w http.ResponseWriter) error {
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(response); err != nil {
@@ -3302,6 +5025,481 @@ func (response UpdateProvider404JSONResponse) VisitUpdateProviderResponse(w http
 	return err
 }
 
+type GetProviderFencesRequestObject struct {
+	ProviderId ProviderId `json:"providerId"`
+}
+
+type GetProviderFencesResponseObject interface {
+	VisitGetProviderFencesResponse(w http.ResponseWriter) error
+}
+
+type GetProviderFences200JSONResponse []Fence
+
+func (response GetProviderFences200JSONResponse) VisitGetProviderFencesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderFences401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetProviderFences401JSONResponse) VisitGetProviderFencesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderFences403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetProviderFences403JSONResponse) VisitGetProviderFencesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderFences404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetProviderFences404JSONResponse) VisitGetProviderFencesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteProviderLocationRequestObject struct {
+	ProviderId ProviderId `json:"providerId"`
+}
+
+type DeleteProviderLocationResponseObject interface {
+	VisitDeleteProviderLocationResponse(w http.ResponseWriter) error
+}
+
+type DeleteProviderLocation204Response struct {
+}
+
+func (response DeleteProviderLocation204Response) VisitDeleteProviderLocationResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
+}
+
+type DeleteProviderLocation401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response DeleteProviderLocation401JSONResponse) VisitDeleteProviderLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteProviderLocation403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response DeleteProviderLocation403JSONResponse) VisitDeleteProviderLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteProviderLocation404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response DeleteProviderLocation404JSONResponse) VisitDeleteProviderLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderLocationRequestObject struct {
+	ProviderId ProviderId `json:"providerId"`
+}
+
+type GetProviderLocationResponseObject interface {
+	VisitGetProviderLocationResponse(w http.ResponseWriter) error
+}
+
+type GetProviderLocation200JSONResponse Location
+
+func (response GetProviderLocation200JSONResponse) VisitGetProviderLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderLocation401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetProviderLocation401JSONResponse) VisitGetProviderLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderLocation403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetProviderLocation403JSONResponse) VisitGetProviderLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderLocation404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetProviderLocation404JSONResponse) VisitGetProviderLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderLocationRequestObject struct {
+	ProviderId ProviderId `json:"providerId"`
+	Body       *PutProviderLocationJSONRequestBody
+}
+
+type PutProviderLocationResponseObject interface {
+	VisitPutProviderLocationResponse(w http.ResponseWriter) error
+}
+
+type PutProviderLocation202Response struct {
+}
+
+func (response PutProviderLocation202Response) VisitPutProviderLocationResponse(w http.ResponseWriter) error {
+	w.WriteHeader(202)
+	return nil
+}
+
+type PutProviderLocation400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response PutProviderLocation400JSONResponse) VisitPutProviderLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderLocation401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response PutProviderLocation401JSONResponse) VisitPutProviderLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderLocation403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response PutProviderLocation403JSONResponse) VisitPutProviderLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderLocation404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response PutProviderLocation404JSONResponse) VisitPutProviderLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderProximityRequestObject struct {
+	ProviderId ProviderId `json:"providerId"`
+	Body       *PutProviderProximityJSONRequestBody
+}
+
+type PutProviderProximityResponseObject interface {
+	VisitPutProviderProximityResponse(w http.ResponseWriter) error
+}
+
+type PutProviderProximity202Response struct {
+}
+
+func (response PutProviderProximity202Response) VisitPutProviderProximityResponse(w http.ResponseWriter) error {
+	w.WriteHeader(202)
+	return nil
+}
+
+type PutProviderProximity400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response PutProviderProximity400JSONResponse) VisitPutProviderProximityResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderProximity401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response PutProviderProximity401JSONResponse) VisitPutProviderProximityResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderProximity403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response PutProviderProximity403JSONResponse) VisitPutProviderProximityResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderProximity404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response PutProviderProximity404JSONResponse) VisitPutProviderProximityResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderSensorsRequestObject struct {
+	ProviderId ProviderId `json:"providerId"`
+}
+
+type GetProviderSensorsResponseObject interface {
+	VisitGetProviderSensorsResponse(w http.ResponseWriter) error
+}
+
+type GetProviderSensors200JSONResponse ExtensionProperties
+
+func (response GetProviderSensors200JSONResponse) VisitGetProviderSensorsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderSensors401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetProviderSensors401JSONResponse) VisitGetProviderSensorsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderSensors403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetProviderSensors403JSONResponse) VisitGetProviderSensorsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetProviderSensors404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetProviderSensors404JSONResponse) VisitGetProviderSensorsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderSensorsRequestObject struct {
+	ProviderId ProviderId `json:"providerId"`
+	Body       *PutProviderSensorsJSONRequestBody
+}
+
+type PutProviderSensorsResponseObject interface {
+	VisitPutProviderSensorsResponse(w http.ResponseWriter) error
+}
+
+type PutProviderSensors200JSONResponse LocationProvider
+
+func (response PutProviderSensors200JSONResponse) VisitPutProviderSensorsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderSensors400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response PutProviderSensors400JSONResponse) VisitPutProviderSensorsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderSensors401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response PutProviderSensors401JSONResponse) VisitPutProviderSensorsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderSensors403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response PutProviderSensors403JSONResponse) VisitPutProviderSensorsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutProviderSensors404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response PutProviderSensors404JSONResponse) VisitPutProviderSensorsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 type PutRPCRequestObject struct {
 	Body *PutRPCJSONRequestBody
 }
@@ -3423,6 +5621,49 @@ func (response GetRPCAvailable403JSONResponse) VisitGetRPCAvailableResponse(w ht
 	return err
 }
 
+type DeleteTrackablesRequestObject struct {
+}
+
+type DeleteTrackablesResponseObject interface {
+	VisitDeleteTrackablesResponse(w http.ResponseWriter) error
+}
+
+type DeleteTrackables204Response struct {
+}
+
+func (response DeleteTrackables204Response) VisitDeleteTrackablesResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
+}
+
+type DeleteTrackables401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response DeleteTrackables401JSONResponse) VisitDeleteTrackablesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteTrackables403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response DeleteTrackables403JSONResponse) VisitDeleteTrackablesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 type ListTrackablesRequestObject struct {
 }
 
@@ -3525,6 +5766,104 @@ func (response CreateTrackable401JSONResponse) VisitCreateTrackableResponse(w ht
 type CreateTrackable403JSONResponse struct{ ForbiddenJSONResponse }
 
 func (response CreateTrackable403JSONResponse) VisitCreateTrackableResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableMotionsRequestObject struct {
+}
+
+type GetTrackableMotionsResponseObject interface {
+	VisitGetTrackableMotionsResponse(w http.ResponseWriter) error
+}
+
+type GetTrackableMotions200JSONResponse []TrackableMotion
+
+func (response GetTrackableMotions200JSONResponse) VisitGetTrackableMotionsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableMotions401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetTrackableMotions401JSONResponse) VisitGetTrackableMotionsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableMotions403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetTrackableMotions403JSONResponse) VisitGetTrackableMotionsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackablesSummaryRequestObject struct {
+}
+
+type GetTrackablesSummaryResponseObject interface {
+	VisitGetTrackablesSummaryResponse(w http.ResponseWriter) error
+}
+
+type GetTrackablesSummary200JSONResponse ResourceSummary
+
+func (response GetTrackablesSummary200JSONResponse) VisitGetTrackablesSummaryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackablesSummary401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetTrackablesSummary401JSONResponse) VisitGetTrackablesSummaryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackablesSummary403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetTrackablesSummary403JSONResponse) VisitGetTrackablesSummaryResponse(w http.ResponseWriter) error {
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(response); err != nil {
@@ -3737,6 +6076,433 @@ func (response UpdateTrackable404JSONResponse) VisitUpdateTrackableResponse(w ht
 	return err
 }
 
+type GetTrackableFencesRequestObject struct {
+	TrackableId TrackableId `json:"trackableId"`
+}
+
+type GetTrackableFencesResponseObject interface {
+	VisitGetTrackableFencesResponse(w http.ResponseWriter) error
+}
+
+type GetTrackableFences200JSONResponse []Fence
+
+func (response GetTrackableFences200JSONResponse) VisitGetTrackableFencesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableFences401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetTrackableFences401JSONResponse) VisitGetTrackableFencesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableFences403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetTrackableFences403JSONResponse) VisitGetTrackableFencesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableFences404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetTrackableFences404JSONResponse) VisitGetTrackableFencesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableLocationRequestObject struct {
+	TrackableId TrackableId `json:"trackableId"`
+}
+
+type GetTrackableLocationResponseObject interface {
+	VisitGetTrackableLocationResponse(w http.ResponseWriter) error
+}
+
+type GetTrackableLocation200JSONResponse Location
+
+func (response GetTrackableLocation200JSONResponse) VisitGetTrackableLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableLocation401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetTrackableLocation401JSONResponse) VisitGetTrackableLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableLocation403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetTrackableLocation403JSONResponse) VisitGetTrackableLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableLocation404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetTrackableLocation404JSONResponse) VisitGetTrackableLocationResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableLocationsRequestObject struct {
+	TrackableId TrackableId `json:"trackableId"`
+}
+
+type GetTrackableLocationsResponseObject interface {
+	VisitGetTrackableLocationsResponse(w http.ResponseWriter) error
+}
+
+type GetTrackableLocations200JSONResponse []Location
+
+func (response GetTrackableLocations200JSONResponse) VisitGetTrackableLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableLocations401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetTrackableLocations401JSONResponse) VisitGetTrackableLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableLocations403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetTrackableLocations403JSONResponse) VisitGetTrackableLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableLocations404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetTrackableLocations404JSONResponse) VisitGetTrackableLocationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableMotionRequestObject struct {
+	TrackableId TrackableId `json:"trackableId"`
+}
+
+type GetTrackableMotionResponseObject interface {
+	VisitGetTrackableMotionResponse(w http.ResponseWriter) error
+}
+
+type GetTrackableMotion200JSONResponse TrackableMotion
+
+func (response GetTrackableMotion200JSONResponse) VisitGetTrackableMotionResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableMotion401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetTrackableMotion401JSONResponse) VisitGetTrackableMotionResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableMotion403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetTrackableMotion403JSONResponse) VisitGetTrackableMotionResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableMotion404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetTrackableMotion404JSONResponse) VisitGetTrackableMotionResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableProvidersRequestObject struct {
+	TrackableId TrackableId `json:"trackableId"`
+}
+
+type GetTrackableProvidersResponseObject interface {
+	VisitGetTrackableProvidersResponse(w http.ResponseWriter) error
+}
+
+type GetTrackableProviders200JSONResponse []LocationProvider
+
+func (response GetTrackableProviders200JSONResponse) VisitGetTrackableProvidersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableProviders401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetTrackableProviders401JSONResponse) VisitGetTrackableProvidersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableProviders403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetTrackableProviders403JSONResponse) VisitGetTrackableProvidersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableProviders404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetTrackableProviders404JSONResponse) VisitGetTrackableProvidersResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableSensorsRequestObject struct {
+	TrackableId TrackableId `json:"trackableId"`
+}
+
+type GetTrackableSensorsResponseObject interface {
+	VisitGetTrackableSensorsResponse(w http.ResponseWriter) error
+}
+
+type GetTrackableSensors200JSONResponse map[string]ExtensionProperties
+
+func (response GetTrackableSensors200JSONResponse) VisitGetTrackableSensorsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableSensors401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetTrackableSensors401JSONResponse) VisitGetTrackableSensorsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableSensors403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetTrackableSensors403JSONResponse) VisitGetTrackableSensorsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetTrackableSensors404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetTrackableSensors404JSONResponse) VisitGetTrackableSensorsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteZonesRequestObject struct {
+}
+
+type DeleteZonesResponseObject interface {
+	VisitDeleteZonesResponse(w http.ResponseWriter) error
+}
+
+type DeleteZones204Response struct {
+}
+
+func (response DeleteZones204Response) VisitDeleteZonesResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
+}
+
+type DeleteZones401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response DeleteZones401JSONResponse) VisitDeleteZonesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteZones403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response DeleteZones403JSONResponse) VisitDeleteZonesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 type ListZonesRequestObject struct {
 }
 
@@ -3839,6 +6605,55 @@ func (response CreateZone401JSONResponse) VisitCreateZoneResponse(w http.Respons
 type CreateZone403JSONResponse struct{ ForbiddenJSONResponse }
 
 func (response CreateZone403JSONResponse) VisitCreateZoneResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetZonesSummaryRequestObject struct {
+}
+
+type GetZonesSummaryResponseObject interface {
+	VisitGetZonesSummaryResponse(w http.ResponseWriter) error
+}
+
+type GetZonesSummary200JSONResponse ResourceSummary
+
+func (response GetZonesSummary200JSONResponse) VisitGetZonesSummaryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetZonesSummary401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetZonesSummary401JSONResponse) VisitGetZonesSummaryResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetZonesSummary403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetZonesSummary403JSONResponse) VisitGetZonesSummaryResponse(w http.ResponseWriter) error {
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(response); err != nil {
@@ -4051,14 +6866,183 @@ func (response UpdateZone404JSONResponse) VisitUpdateZoneResponse(w http.Respons
 	return err
 }
 
+type GetZoneCreateFenceRequestObject struct {
+	ZoneId ZoneId `json:"zoneId"`
+}
+
+type GetZoneCreateFenceResponseObject interface {
+	VisitGetZoneCreateFenceResponse(w http.ResponseWriter) error
+}
+
+type GetZoneCreateFence200JSONResponse Fence
+
+func (response GetZoneCreateFence200JSONResponse) VisitGetZoneCreateFenceResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetZoneCreateFence400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response GetZoneCreateFence400JSONResponse) VisitGetZoneCreateFenceResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetZoneCreateFence401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetZoneCreateFence401JSONResponse) VisitGetZoneCreateFenceResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetZoneCreateFence403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetZoneCreateFence403JSONResponse) VisitGetZoneCreateFenceResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type GetZoneCreateFence404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetZoneCreateFence404JSONResponse) VisitGetZoneCreateFenceResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutZoneTransformRequestObject struct {
+	ZoneId ZoneId `json:"zoneId"`
+	Body   *PutZoneTransformJSONRequestBody
+}
+
+type PutZoneTransformResponseObject interface {
+	VisitPutZoneTransformResponse(w http.ResponseWriter) error
+}
+
+type PutZoneTransform200JSONResponse struct {
+	Crs string `json:"crs"`
+
+	// Position GeoJSON point geometry.
+	Position Point              `json:"position"`
+	ZoneId   openapi_types.UUID `json:"zone_id"`
+}
+
+func (response PutZoneTransform200JSONResponse) VisitPutZoneTransformResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutZoneTransform400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response PutZoneTransform400JSONResponse) VisitPutZoneTransformResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutZoneTransform401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response PutZoneTransform401JSONResponse) VisitPutZoneTransformResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutZoneTransform403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response PutZoneTransform403JSONResponse) VisitPutZoneTransformResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type PutZoneTransform404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response PutZoneTransform404JSONResponse) VisitPutZoneTransformResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
+	// Delete all fences
+	// (DELETE /v2/fences)
+	DeleteFences(ctx context.Context, request DeleteFencesRequestObject) (DeleteFencesResponseObject, error)
 	// List fences
 	// (GET /v2/fences)
 	ListFences(ctx context.Context, request ListFencesRequestObject) (ListFencesResponseObject, error)
 	// Create a fence
 	// (POST /v2/fences)
 	CreateFence(ctx context.Context, request CreateFenceRequestObject) (CreateFenceResponseObject, error)
+	// Get fence summary
+	// (GET /v2/fences/summary)
+	GetFencesSummary(ctx context.Context, request GetFencesSummaryRequestObject) (GetFencesSummaryResponseObject, error)
 	// Delete a fence
 	// (DELETE /v2/fences/{fenceId})
 	DeleteFence(ctx context.Context, request DeleteFenceRequestObject) (DeleteFenceResponseObject, error)
@@ -4068,18 +7052,42 @@ type StrictServerInterface interface {
 	// Update a fence
 	// (PUT /v2/fences/{fenceId})
 	UpdateFence(ctx context.Context, request UpdateFenceRequestObject) (UpdateFenceResponseObject, error)
+	// Get fence locations
+	// (GET /v2/fences/{fenceId}/locations)
+	GetFenceLocations(ctx context.Context, request GetFenceLocationsRequestObject) (GetFenceLocationsResponseObject, error)
+	// Get fence providers
+	// (GET /v2/fences/{fenceId}/providers)
+	GetFenceProviders(ctx context.Context, request GetFenceProvidersRequestObject) (GetFenceProvidersResponseObject, error)
+	// Delete all providers
+	// (DELETE /v2/providers)
+	DeleteProviders(ctx context.Context, request DeleteProvidersRequestObject) (DeleteProvidersResponseObject, error)
 	// List providers
 	// (GET /v2/providers)
 	ListProviders(ctx context.Context, request ListProvidersRequestObject) (ListProvidersResponseObject, error)
 	// Create a provider
 	// (POST /v2/providers)
 	CreateProvider(ctx context.Context, request CreateProviderRequestObject) (CreateProviderResponseObject, error)
+	// Delete provider locations
+	// (DELETE /v2/providers/locations)
+	DeleteProviderLocations(ctx context.Context, request DeleteProviderLocationsRequestObject) (DeleteProviderLocationsResponseObject, error)
+	// Get provider locations
+	// (GET /v2/providers/locations)
+	GetProviderLocations(ctx context.Context, request GetProviderLocationsRequestObject) (GetProviderLocationsResponseObject, error)
 	// Ingest locations
 	// (POST /v2/providers/locations)
 	PostProviderLocations(ctx context.Context, request PostProviderLocationsRequestObject) (PostProviderLocationsResponseObject, error)
+	// Replace provider locations
+	// (PUT /v2/providers/locations)
+	PutProviderLocations(ctx context.Context, request PutProviderLocationsRequestObject) (PutProviderLocationsResponseObject, error)
 	// Ingest proximities
 	// (POST /v2/providers/proximities)
 	PostProviderProximities(ctx context.Context, request PostProviderProximitiesRequestObject) (PostProviderProximitiesResponseObject, error)
+	// Replace provider proximities
+	// (PUT /v2/providers/proximities)
+	PutProviderProximities(ctx context.Context, request PutProviderProximitiesRequestObject) (PutProviderProximitiesResponseObject, error)
+	// Get provider summary
+	// (GET /v2/providers/summary)
+	GetProvidersSummary(ctx context.Context, request GetProvidersSummaryRequestObject) (GetProvidersSummaryResponseObject, error)
 	// Delete a provider
 	// (DELETE /v2/providers/{providerId})
 	DeleteProvider(ctx context.Context, request DeleteProviderRequestObject) (DeleteProviderResponseObject, error)
@@ -4089,18 +7097,48 @@ type StrictServerInterface interface {
 	// Update a provider
 	// (PUT /v2/providers/{providerId})
 	UpdateProvider(ctx context.Context, request UpdateProviderRequestObject) (UpdateProviderResponseObject, error)
+	// Get provider fences
+	// (GET /v2/providers/{providerId}/fences)
+	GetProviderFences(ctx context.Context, request GetProviderFencesRequestObject) (GetProviderFencesResponseObject, error)
+	// Delete provider location
+	// (DELETE /v2/providers/{providerId}/location)
+	DeleteProviderLocation(ctx context.Context, request DeleteProviderLocationRequestObject) (DeleteProviderLocationResponseObject, error)
+	// Get provider location
+	// (GET /v2/providers/{providerId}/location)
+	GetProviderLocation(ctx context.Context, request GetProviderLocationRequestObject) (GetProviderLocationResponseObject, error)
+	// Update provider location
+	// (PUT /v2/providers/{providerId}/location)
+	PutProviderLocation(ctx context.Context, request PutProviderLocationRequestObject) (PutProviderLocationResponseObject, error)
+	// Update provider proximity
+	// (PUT /v2/providers/{providerId}/proximity)
+	PutProviderProximity(ctx context.Context, request PutProviderProximityRequestObject) (PutProviderProximityResponseObject, error)
+	// Get provider sensors
+	// (GET /v2/providers/{providerId}/sensors)
+	GetProviderSensors(ctx context.Context, request GetProviderSensorsRequestObject) (GetProviderSensorsResponseObject, error)
+	// Update provider sensors
+	// (PUT /v2/providers/{providerId}/sensors)
+	PutProviderSensors(ctx context.Context, request PutProviderSensorsRequestObject) (PutProviderSensorsResponseObject, error)
 	// Invoke JSON-RPC
 	// (PUT /v2/rpc)
 	PutRPC(ctx context.Context, request PutRPCRequestObject) (PutRPCResponseObject, error)
 	// List available RPC methods
 	// (GET /v2/rpc/available)
 	GetRPCAvailable(ctx context.Context, request GetRPCAvailableRequestObject) (GetRPCAvailableResponseObject, error)
+	// Delete all trackables
+	// (DELETE /v2/trackables)
+	DeleteTrackables(ctx context.Context, request DeleteTrackablesRequestObject) (DeleteTrackablesResponseObject, error)
 	// List trackables
 	// (GET /v2/trackables)
 	ListTrackables(ctx context.Context, request ListTrackablesRequestObject) (ListTrackablesResponseObject, error)
 	// Create a trackable
 	// (POST /v2/trackables)
 	CreateTrackable(ctx context.Context, request CreateTrackableRequestObject) (CreateTrackableResponseObject, error)
+	// List trackable motions
+	// (GET /v2/trackables/motions)
+	GetTrackableMotions(ctx context.Context, request GetTrackableMotionsRequestObject) (GetTrackableMotionsResponseObject, error)
+	// Get trackable summary
+	// (GET /v2/trackables/summary)
+	GetTrackablesSummary(ctx context.Context, request GetTrackablesSummaryRequestObject) (GetTrackablesSummaryResponseObject, error)
 	// Delete a trackable
 	// (DELETE /v2/trackables/{trackableId})
 	DeleteTrackable(ctx context.Context, request DeleteTrackableRequestObject) (DeleteTrackableResponseObject, error)
@@ -4110,12 +7148,36 @@ type StrictServerInterface interface {
 	// Update a trackable
 	// (PUT /v2/trackables/{trackableId})
 	UpdateTrackable(ctx context.Context, request UpdateTrackableRequestObject) (UpdateTrackableResponseObject, error)
+	// Get trackable fences
+	// (GET /v2/trackables/{trackableId}/fences)
+	GetTrackableFences(ctx context.Context, request GetTrackableFencesRequestObject) (GetTrackableFencesResponseObject, error)
+	// Get trackable location
+	// (GET /v2/trackables/{trackableId}/location)
+	GetTrackableLocation(ctx context.Context, request GetTrackableLocationRequestObject) (GetTrackableLocationResponseObject, error)
+	// Get trackable locations
+	// (GET /v2/trackables/{trackableId}/locations)
+	GetTrackableLocations(ctx context.Context, request GetTrackableLocationsRequestObject) (GetTrackableLocationsResponseObject, error)
+	// Get trackable motion
+	// (GET /v2/trackables/{trackableId}/motion)
+	GetTrackableMotion(ctx context.Context, request GetTrackableMotionRequestObject) (GetTrackableMotionResponseObject, error)
+	// Get trackable providers
+	// (GET /v2/trackables/{trackableId}/providers)
+	GetTrackableProviders(ctx context.Context, request GetTrackableProvidersRequestObject) (GetTrackableProvidersResponseObject, error)
+	// Get trackable sensors
+	// (GET /v2/trackables/{trackableId}/sensors)
+	GetTrackableSensors(ctx context.Context, request GetTrackableSensorsRequestObject) (GetTrackableSensorsResponseObject, error)
+	// Delete all zones
+	// (DELETE /v2/zones)
+	DeleteZones(ctx context.Context, request DeleteZonesRequestObject) (DeleteZonesResponseObject, error)
 	// List zones
 	// (GET /v2/zones)
 	ListZones(ctx context.Context, request ListZonesRequestObject) (ListZonesResponseObject, error)
 	// Create a zone
 	// (POST /v2/zones)
 	CreateZone(ctx context.Context, request CreateZoneRequestObject) (CreateZoneResponseObject, error)
+	// Get zone summary
+	// (GET /v2/zones/summary)
+	GetZonesSummary(ctx context.Context, request GetZonesSummaryRequestObject) (GetZonesSummaryResponseObject, error)
 	// Delete a zone
 	// (DELETE /v2/zones/{zoneId})
 	DeleteZone(ctx context.Context, request DeleteZoneRequestObject) (DeleteZoneResponseObject, error)
@@ -4125,6 +7187,12 @@ type StrictServerInterface interface {
 	// Update a zone
 	// (PUT /v2/zones/{zoneId})
 	UpdateZone(ctx context.Context, request UpdateZoneRequestObject) (UpdateZoneResponseObject, error)
+	// Create fence from zone
+	// (GET /v2/zones/{zoneId}/createfence)
+	GetZoneCreateFence(ctx context.Context, request GetZoneCreateFenceRequestObject) (GetZoneCreateFenceResponseObject, error)
+	// Update zone transform
+	// (PUT /v2/zones/{zoneId}/transform)
+	PutZoneTransform(ctx context.Context, request PutZoneTransformRequestObject) (PutZoneTransformResponseObject, error)
 }
 
 type StrictHandlerFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, request any) (any, error)
@@ -4154,6 +7222,30 @@ type strictHandler struct {
 	ssi         StrictServerInterface
 	middlewares []StrictMiddlewareFunc
 	options     StrictHTTPServerOptions
+}
+
+// DeleteFences operation middleware
+func (sh *strictHandler) DeleteFences(w http.ResponseWriter, r *http.Request) {
+	var request DeleteFencesRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteFences(ctx, request.(DeleteFencesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteFences")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeleteFencesResponseObject); ok {
+		if err := validResponse.VisitDeleteFencesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
 }
 
 // ListFences operation middleware
@@ -4204,6 +7296,30 @@ func (sh *strictHandler) CreateFence(w http.ResponseWriter, r *http.Request) {
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(CreateFenceResponseObject); ok {
 		if err := validResponse.VisitCreateFenceResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetFencesSummary operation middleware
+func (sh *strictHandler) GetFencesSummary(w http.ResponseWriter, r *http.Request) {
+	var request GetFencesSummaryRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetFencesSummary(ctx, request.(GetFencesSummaryRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetFencesSummary")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetFencesSummaryResponseObject); ok {
+		if err := validResponse.VisitGetFencesSummaryResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -4296,6 +7412,82 @@ func (sh *strictHandler) UpdateFence(w http.ResponseWriter, r *http.Request, fen
 	}
 }
 
+// GetFenceLocations operation middleware
+func (sh *strictHandler) GetFenceLocations(w http.ResponseWriter, r *http.Request, fenceId FenceId) {
+	var request GetFenceLocationsRequestObject
+
+	request.FenceId = fenceId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetFenceLocations(ctx, request.(GetFenceLocationsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetFenceLocations")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetFenceLocationsResponseObject); ok {
+		if err := validResponse.VisitGetFenceLocationsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetFenceProviders operation middleware
+func (sh *strictHandler) GetFenceProviders(w http.ResponseWriter, r *http.Request, fenceId FenceId) {
+	var request GetFenceProvidersRequestObject
+
+	request.FenceId = fenceId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetFenceProviders(ctx, request.(GetFenceProvidersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetFenceProviders")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetFenceProvidersResponseObject); ok {
+		if err := validResponse.VisitGetFenceProvidersResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// DeleteProviders operation middleware
+func (sh *strictHandler) DeleteProviders(w http.ResponseWriter, r *http.Request) {
+	var request DeleteProvidersRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteProviders(ctx, request.(DeleteProvidersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteProviders")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeleteProvidersResponseObject); ok {
+		if err := validResponse.VisitDeleteProvidersResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // ListProviders operation middleware
 func (sh *strictHandler) ListProviders(w http.ResponseWriter, r *http.Request) {
 	var request ListProvidersRequestObject
@@ -4351,6 +7543,54 @@ func (sh *strictHandler) CreateProvider(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
+// DeleteProviderLocations operation middleware
+func (sh *strictHandler) DeleteProviderLocations(w http.ResponseWriter, r *http.Request) {
+	var request DeleteProviderLocationsRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteProviderLocations(ctx, request.(DeleteProviderLocationsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteProviderLocations")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeleteProviderLocationsResponseObject); ok {
+		if err := validResponse.VisitDeleteProviderLocationsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetProviderLocations operation middleware
+func (sh *strictHandler) GetProviderLocations(w http.ResponseWriter, r *http.Request) {
+	var request GetProviderLocationsRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetProviderLocations(ctx, request.(GetProviderLocationsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetProviderLocations")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetProviderLocationsResponseObject); ok {
+		if err := validResponse.VisitGetProviderLocationsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // PostProviderLocations operation middleware
 func (sh *strictHandler) PostProviderLocations(w http.ResponseWriter, r *http.Request) {
 	var request PostProviderLocationsRequestObject
@@ -4382,6 +7622,37 @@ func (sh *strictHandler) PostProviderLocations(w http.ResponseWriter, r *http.Re
 	}
 }
 
+// PutProviderLocations operation middleware
+func (sh *strictHandler) PutProviderLocations(w http.ResponseWriter, r *http.Request) {
+	var request PutProviderLocationsRequestObject
+
+	var body PutProviderLocationsJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.PutProviderLocations(ctx, request.(PutProviderLocationsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PutProviderLocations")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(PutProviderLocationsResponseObject); ok {
+		if err := validResponse.VisitPutProviderLocationsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // PostProviderProximities operation middleware
 func (sh *strictHandler) PostProviderProximities(w http.ResponseWriter, r *http.Request) {
 	var request PostProviderProximitiesRequestObject
@@ -4406,6 +7677,61 @@ func (sh *strictHandler) PostProviderProximities(w http.ResponseWriter, r *http.
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(PostProviderProximitiesResponseObject); ok {
 		if err := validResponse.VisitPostProviderProximitiesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// PutProviderProximities operation middleware
+func (sh *strictHandler) PutProviderProximities(w http.ResponseWriter, r *http.Request) {
+	var request PutProviderProximitiesRequestObject
+
+	var body PutProviderProximitiesJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.PutProviderProximities(ctx, request.(PutProviderProximitiesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PutProviderProximities")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(PutProviderProximitiesResponseObject); ok {
+		if err := validResponse.VisitPutProviderProximitiesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetProvidersSummary operation middleware
+func (sh *strictHandler) GetProvidersSummary(w http.ResponseWriter, r *http.Request) {
+	var request GetProvidersSummaryRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetProvidersSummary(ctx, request.(GetProvidersSummaryRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetProvidersSummary")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetProvidersSummaryResponseObject); ok {
+		if err := validResponse.VisitGetProvidersSummaryResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -4498,6 +7824,209 @@ func (sh *strictHandler) UpdateProvider(w http.ResponseWriter, r *http.Request, 
 	}
 }
 
+// GetProviderFences operation middleware
+func (sh *strictHandler) GetProviderFences(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	var request GetProviderFencesRequestObject
+
+	request.ProviderId = providerId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetProviderFences(ctx, request.(GetProviderFencesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetProviderFences")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetProviderFencesResponseObject); ok {
+		if err := validResponse.VisitGetProviderFencesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// DeleteProviderLocation operation middleware
+func (sh *strictHandler) DeleteProviderLocation(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	var request DeleteProviderLocationRequestObject
+
+	request.ProviderId = providerId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteProviderLocation(ctx, request.(DeleteProviderLocationRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteProviderLocation")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeleteProviderLocationResponseObject); ok {
+		if err := validResponse.VisitDeleteProviderLocationResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetProviderLocation operation middleware
+func (sh *strictHandler) GetProviderLocation(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	var request GetProviderLocationRequestObject
+
+	request.ProviderId = providerId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetProviderLocation(ctx, request.(GetProviderLocationRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetProviderLocation")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetProviderLocationResponseObject); ok {
+		if err := validResponse.VisitGetProviderLocationResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// PutProviderLocation operation middleware
+func (sh *strictHandler) PutProviderLocation(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	var request PutProviderLocationRequestObject
+
+	request.ProviderId = providerId
+
+	var body PutProviderLocationJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.PutProviderLocation(ctx, request.(PutProviderLocationRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PutProviderLocation")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(PutProviderLocationResponseObject); ok {
+		if err := validResponse.VisitPutProviderLocationResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// PutProviderProximity operation middleware
+func (sh *strictHandler) PutProviderProximity(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	var request PutProviderProximityRequestObject
+
+	request.ProviderId = providerId
+
+	var body PutProviderProximityJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.PutProviderProximity(ctx, request.(PutProviderProximityRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PutProviderProximity")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(PutProviderProximityResponseObject); ok {
+		if err := validResponse.VisitPutProviderProximityResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetProviderSensors operation middleware
+func (sh *strictHandler) GetProviderSensors(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	var request GetProviderSensorsRequestObject
+
+	request.ProviderId = providerId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetProviderSensors(ctx, request.(GetProviderSensorsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetProviderSensors")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetProviderSensorsResponseObject); ok {
+		if err := validResponse.VisitGetProviderSensorsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// PutProviderSensors operation middleware
+func (sh *strictHandler) PutProviderSensors(w http.ResponseWriter, r *http.Request, providerId ProviderId) {
+	var request PutProviderSensorsRequestObject
+
+	request.ProviderId = providerId
+
+	var body PutProviderSensorsJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.PutProviderSensors(ctx, request.(PutProviderSensorsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PutProviderSensors")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(PutProviderSensorsResponseObject); ok {
+		if err := validResponse.VisitPutProviderSensorsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // PutRPC operation middleware
 func (sh *strictHandler) PutRPC(w http.ResponseWriter, r *http.Request) {
 	var request PutRPCRequestObject
@@ -4553,6 +8082,30 @@ func (sh *strictHandler) GetRPCAvailable(w http.ResponseWriter, r *http.Request)
 	}
 }
 
+// DeleteTrackables operation middleware
+func (sh *strictHandler) DeleteTrackables(w http.ResponseWriter, r *http.Request) {
+	var request DeleteTrackablesRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteTrackables(ctx, request.(DeleteTrackablesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteTrackables")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeleteTrackablesResponseObject); ok {
+		if err := validResponse.VisitDeleteTrackablesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // ListTrackables operation middleware
 func (sh *strictHandler) ListTrackables(w http.ResponseWriter, r *http.Request) {
 	var request ListTrackablesRequestObject
@@ -4601,6 +8154,54 @@ func (sh *strictHandler) CreateTrackable(w http.ResponseWriter, r *http.Request)
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(CreateTrackableResponseObject); ok {
 		if err := validResponse.VisitCreateTrackableResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetTrackableMotions operation middleware
+func (sh *strictHandler) GetTrackableMotions(w http.ResponseWriter, r *http.Request) {
+	var request GetTrackableMotionsRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetTrackableMotions(ctx, request.(GetTrackableMotionsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetTrackableMotions")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetTrackableMotionsResponseObject); ok {
+		if err := validResponse.VisitGetTrackableMotionsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetTrackablesSummary operation middleware
+func (sh *strictHandler) GetTrackablesSummary(w http.ResponseWriter, r *http.Request) {
+	var request GetTrackablesSummaryRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetTrackablesSummary(ctx, request.(GetTrackablesSummaryRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetTrackablesSummary")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetTrackablesSummaryResponseObject); ok {
+		if err := validResponse.VisitGetTrackablesSummaryResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -4693,6 +8294,186 @@ func (sh *strictHandler) UpdateTrackable(w http.ResponseWriter, r *http.Request,
 	}
 }
 
+// GetTrackableFences operation middleware
+func (sh *strictHandler) GetTrackableFences(w http.ResponseWriter, r *http.Request, trackableId TrackableId) {
+	var request GetTrackableFencesRequestObject
+
+	request.TrackableId = trackableId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetTrackableFences(ctx, request.(GetTrackableFencesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetTrackableFences")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetTrackableFencesResponseObject); ok {
+		if err := validResponse.VisitGetTrackableFencesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetTrackableLocation operation middleware
+func (sh *strictHandler) GetTrackableLocation(w http.ResponseWriter, r *http.Request, trackableId TrackableId) {
+	var request GetTrackableLocationRequestObject
+
+	request.TrackableId = trackableId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetTrackableLocation(ctx, request.(GetTrackableLocationRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetTrackableLocation")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetTrackableLocationResponseObject); ok {
+		if err := validResponse.VisitGetTrackableLocationResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetTrackableLocations operation middleware
+func (sh *strictHandler) GetTrackableLocations(w http.ResponseWriter, r *http.Request, trackableId TrackableId) {
+	var request GetTrackableLocationsRequestObject
+
+	request.TrackableId = trackableId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetTrackableLocations(ctx, request.(GetTrackableLocationsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetTrackableLocations")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetTrackableLocationsResponseObject); ok {
+		if err := validResponse.VisitGetTrackableLocationsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetTrackableMotion operation middleware
+func (sh *strictHandler) GetTrackableMotion(w http.ResponseWriter, r *http.Request, trackableId TrackableId) {
+	var request GetTrackableMotionRequestObject
+
+	request.TrackableId = trackableId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetTrackableMotion(ctx, request.(GetTrackableMotionRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetTrackableMotion")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetTrackableMotionResponseObject); ok {
+		if err := validResponse.VisitGetTrackableMotionResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetTrackableProviders operation middleware
+func (sh *strictHandler) GetTrackableProviders(w http.ResponseWriter, r *http.Request, trackableId TrackableId) {
+	var request GetTrackableProvidersRequestObject
+
+	request.TrackableId = trackableId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetTrackableProviders(ctx, request.(GetTrackableProvidersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetTrackableProviders")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetTrackableProvidersResponseObject); ok {
+		if err := validResponse.VisitGetTrackableProvidersResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetTrackableSensors operation middleware
+func (sh *strictHandler) GetTrackableSensors(w http.ResponseWriter, r *http.Request, trackableId TrackableId) {
+	var request GetTrackableSensorsRequestObject
+
+	request.TrackableId = trackableId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetTrackableSensors(ctx, request.(GetTrackableSensorsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetTrackableSensors")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetTrackableSensorsResponseObject); ok {
+		if err := validResponse.VisitGetTrackableSensorsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// DeleteZones operation middleware
+func (sh *strictHandler) DeleteZones(w http.ResponseWriter, r *http.Request) {
+	var request DeleteZonesRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteZones(ctx, request.(DeleteZonesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteZones")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeleteZonesResponseObject); ok {
+		if err := validResponse.VisitDeleteZonesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // ListZones operation middleware
 func (sh *strictHandler) ListZones(w http.ResponseWriter, r *http.Request) {
 	var request ListZonesRequestObject
@@ -4741,6 +8522,30 @@ func (sh *strictHandler) CreateZone(w http.ResponseWriter, r *http.Request) {
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(CreateZoneResponseObject); ok {
 		if err := validResponse.VisitCreateZoneResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetZonesSummary operation middleware
+func (sh *strictHandler) GetZonesSummary(w http.ResponseWriter, r *http.Request) {
+	var request GetZonesSummaryRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetZonesSummary(ctx, request.(GetZonesSummaryRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetZonesSummary")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetZonesSummaryResponseObject); ok {
+		if err := validResponse.VisitGetZonesSummaryResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -4826,6 +8631,65 @@ func (sh *strictHandler) UpdateZone(w http.ResponseWriter, r *http.Request, zone
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(UpdateZoneResponseObject); ok {
 		if err := validResponse.VisitUpdateZoneResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetZoneCreateFence operation middleware
+func (sh *strictHandler) GetZoneCreateFence(w http.ResponseWriter, r *http.Request, zoneId ZoneId) {
+	var request GetZoneCreateFenceRequestObject
+
+	request.ZoneId = zoneId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetZoneCreateFence(ctx, request.(GetZoneCreateFenceRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetZoneCreateFence")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetZoneCreateFenceResponseObject); ok {
+		if err := validResponse.VisitGetZoneCreateFenceResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// PutZoneTransform operation middleware
+func (sh *strictHandler) PutZoneTransform(w http.ResponseWriter, r *http.Request, zoneId ZoneId) {
+	var request PutZoneTransformRequestObject
+
+	request.ZoneId = zoneId
+
+	var body PutZoneTransformJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.PutZoneTransform(ctx, request.(PutZoneTransformRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PutZoneTransform")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(PutZoneTransformResponseObject); ok {
+		if err := validResponse.VisitPutZoneTransformResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {

--- a/internal/httpapi/handlers/handlers.go
+++ b/internal/httpapi/handlers/handlers.go
@@ -47,6 +47,28 @@ type Service interface {
 	DeleteFence(ctx context.Context, id gen.FenceId) error
 }
 
+type extendedService interface {
+	GetZoneCreateFence(ctx context.Context, id gen.ZoneId) (gen.Fence, error)
+	PutZoneTransform(ctx context.Context, id gen.ZoneId, body json.RawMessage) (map[string]any, error)
+	ListProviderLocations(ctx context.Context) ([]gen.Location, error)
+	GetProviderLocation(ctx context.Context, id gen.ProviderId) (gen.Location, error)
+	PutProviderLocation(ctx context.Context, id gen.ProviderId, location gen.Location) error
+	DeleteProviderLocation(ctx context.Context, id gen.ProviderId) error
+	DeleteProviderLocations(ctx context.Context) error
+	PutProviderLocations(ctx context.Context, locations []gen.Location) error
+	PutProviderProximity(ctx context.Context, id gen.ProviderId, proximity gen.Proximity) error
+	PutProviderProximities(ctx context.Context, proximities []gen.Proximity) error
+	ListProviderFences(ctx context.Context, id gen.ProviderId) ([]gen.Fence, error)
+	GetTrackableLocation(ctx context.Context, id gen.TrackableId) (gen.Location, error)
+	ListTrackableLocations(ctx context.Context, id gen.TrackableId) ([]gen.Location, error)
+	GetTrackableMotion(ctx context.Context, id gen.TrackableId) (gen.TrackableMotion, error)
+	ListTrackableMotions(ctx context.Context) ([]gen.TrackableMotion, error)
+	ListTrackableFences(ctx context.Context, id gen.TrackableId) ([]gen.Fence, error)
+	ListTrackableProviders(ctx context.Context, id gen.TrackableId) ([]gen.LocationProvider, error)
+	ListFenceLocations(ctx context.Context, id gen.FenceId) ([]gen.Location, error)
+	ListFenceProviders(ctx context.Context, id gen.FenceId) ([]gen.LocationProvider, error)
+}
+
 // RPCBridge captures the JSON-RPC operations exposed over HTTP.
 type RPCBridge interface {
 	AvailableMethods(ctx context.Context) (gen.RpcAvailableMethods, error)
@@ -66,6 +88,21 @@ func New(deps Dependencies) *Handler {
 func (h *Handler) ListZones(w http.ResponseWriter, r *http.Request) {
 	items, err := h.deps.Service.ListZones(r.Context())
 	writeJSONOrError(w, items, err, http.StatusOK)
+}
+
+func (h *Handler) DeleteZones(w http.ResponseWriter, r *http.Request) {
+	items, err := h.deps.Service.ListZones(r.Context())
+	if err != nil {
+		writeJSONOrError(w, nil, err, 0)
+		return
+	}
+	for _, item := range items {
+		if err := h.deps.Service.DeleteZone(r.Context(), item.Id); err != nil {
+			writeJSONOrError(w, nil, err, 0)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) CreateZone(w http.ResponseWriter, r *http.Request) {
@@ -98,9 +135,54 @@ func (h *Handler) DeleteZone(w http.ResponseWriter, r *http.Request, id gen.Zone
 	writeNoContentOrError(w, err)
 }
 
+func (h *Handler) GetZonesSummary(w http.ResponseWriter, r *http.Request) {
+	items, err := h.deps.Service.ListZones(r.Context())
+	writeJSONOrError(w, summaryResponse("zones", len(items)), err, http.StatusOK)
+}
+
+func (h *Handler) PutZoneTransform(w http.ResponseWriter, r *http.Request, id gen.ZoneId) {
+	body, err := readRawBody(w, r, h.deps.RequestBodyLimitBytes)
+	if err != nil {
+		writeJSONOrError(w, nil, err, 0)
+		return
+	}
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "zone transform is not implemented")
+		return
+	}
+	payload, err := svc.PutZoneTransform(r.Context(), id, body)
+	writeJSONOrError(w, payload, err, http.StatusOK)
+}
+
+func (h *Handler) GetZoneCreateFence(w http.ResponseWriter, r *http.Request, id gen.ZoneId) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "zone createfence is not implemented")
+		return
+	}
+	item, err := svc.GetZoneCreateFence(r.Context(), id)
+	writeJSONOrError(w, item, err, http.StatusOK)
+}
+
 func (h *Handler) ListTrackables(w http.ResponseWriter, r *http.Request) {
 	items, err := h.deps.Service.ListTrackables(r.Context())
 	writeJSONOrError(w, items, err, http.StatusOK)
+}
+
+func (h *Handler) DeleteTrackables(w http.ResponseWriter, r *http.Request) {
+	items, err := h.deps.Service.ListTrackables(r.Context())
+	if err != nil {
+		writeJSONOrError(w, nil, err, 0)
+		return
+	}
+	for _, item := range items {
+		if err := h.deps.Service.DeleteTrackable(r.Context(), item.Id); err != nil {
+			writeJSONOrError(w, nil, err, 0)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) CreateTrackable(w http.ResponseWriter, r *http.Request) {
@@ -133,9 +215,109 @@ func (h *Handler) DeleteTrackable(w http.ResponseWriter, r *http.Request, id gen
 	writeNoContentOrError(w, err)
 }
 
+func (h *Handler) GetTrackablesSummary(w http.ResponseWriter, r *http.Request) {
+	items, err := h.deps.Service.ListTrackables(r.Context())
+	writeJSONOrError(w, summaryResponse("trackables", len(items)), err, http.StatusOK)
+}
+
+func (h *Handler) GetTrackableMotions(w http.ResponseWriter, r *http.Request) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "trackable motions are not implemented")
+		return
+	}
+	items, err := svc.ListTrackableMotions(r.Context())
+	writeJSONOrError(w, items, err, http.StatusOK)
+}
+
+func (h *Handler) GetTrackableFences(w http.ResponseWriter, r *http.Request, id gen.TrackableId) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "trackable fences are not implemented")
+		return
+	}
+	items, err := svc.ListTrackableFences(r.Context(), id)
+	writeJSONOrError(w, items, err, http.StatusOK)
+}
+
+func (h *Handler) GetTrackableLocation(w http.ResponseWriter, r *http.Request, id gen.TrackableId) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "trackable location is not implemented")
+		return
+	}
+	item, err := svc.GetTrackableLocation(r.Context(), id)
+	writeJSONOrError(w, item, err, http.StatusOK)
+}
+
+func (h *Handler) GetTrackableLocations(w http.ResponseWriter, r *http.Request, id gen.TrackableId) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "trackable locations are not implemented")
+		return
+	}
+	items, err := svc.ListTrackableLocations(r.Context(), id)
+	writeJSONOrError(w, items, err, http.StatusOK)
+}
+
+func (h *Handler) GetTrackableMotion(w http.ResponseWriter, r *http.Request, id gen.TrackableId) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "trackable motion is not implemented")
+		return
+	}
+	item, err := svc.GetTrackableMotion(r.Context(), id)
+	writeJSONOrError(w, item, err, http.StatusOK)
+}
+
+func (h *Handler) GetTrackableProviders(w http.ResponseWriter, r *http.Request, id gen.TrackableId) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "trackable providers are not implemented")
+		return
+	}
+	items, err := svc.ListTrackableProviders(r.Context(), id)
+	writeJSONOrError(w, items, err, http.StatusOK)
+}
+
+func (h *Handler) GetTrackableSensors(w http.ResponseWriter, r *http.Request, id gen.TrackableId) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "trackable sensors are not implemented")
+		return
+	}
+	providers, err := svc.ListTrackableProviders(r.Context(), id)
+	if err != nil {
+		writeJSONOrError(w, nil, err, 0)
+		return
+	}
+	sensors := make(map[string]any, len(providers))
+	for _, provider := range providers {
+		if provider.Sensors != nil {
+			sensors[provider.Id] = *provider.Sensors
+		}
+	}
+	writeJSONOrError(w, sensors, nil, http.StatusOK)
+}
+
 func (h *Handler) ListProviders(w http.ResponseWriter, r *http.Request) {
 	items, err := h.deps.Service.ListProviders(r.Context())
 	writeJSONOrError(w, items, err, http.StatusOK)
+}
+
+func (h *Handler) DeleteProviders(w http.ResponseWriter, r *http.Request) {
+	items, err := h.deps.Service.ListProviders(r.Context())
+	if err != nil {
+		writeJSONOrError(w, nil, err, 0)
+		return
+	}
+	for _, item := range items {
+		if err := h.deps.Service.DeleteProvider(r.Context(), item.Id); err != nil {
+			writeJSONOrError(w, nil, err, 0)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) CreateProvider(w http.ResponseWriter, r *http.Request) {
@@ -168,6 +350,21 @@ func (h *Handler) DeleteProvider(w http.ResponseWriter, r *http.Request, id gen.
 	writeNoContentOrError(w, err)
 }
 
+func (h *Handler) GetProvidersSummary(w http.ResponseWriter, r *http.Request) {
+	items, err := h.deps.Service.ListProviders(r.Context())
+	writeJSONOrError(w, summaryResponse("providers", len(items)), err, http.StatusOK)
+}
+
+func (h *Handler) GetProviderLocations(w http.ResponseWriter, r *http.Request) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "provider locations are not implemented")
+		return
+	}
+	items, err := svc.ListProviderLocations(r.Context())
+	writeJSONOrError(w, items, err, http.StatusOK)
+}
+
 func (h *Handler) PostProviderLocations(w http.ResponseWriter, r *http.Request) {
 	var body []gen.Location
 	if err := decodeJSONBody(w, r, h.deps.RequestBodyLimitBytes, &body); err != nil {
@@ -176,6 +373,31 @@ func (h *Handler) PostProviderLocations(w http.ResponseWriter, r *http.Request) 
 	}
 	err := h.deps.Service.ProcessLocations(observability.WithIngestTransport(r.Context(), "http"), body)
 	writeAcceptedOrError(w, err)
+}
+
+func (h *Handler) PutProviderLocations(w http.ResponseWriter, r *http.Request) {
+	var body []gen.Location
+	if err := decodeJSONBody(w, r, h.deps.RequestBodyLimitBytes, &body); err != nil {
+		writeJSONOrError(w, nil, err, 0)
+		return
+	}
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "bulk provider location replace is not implemented")
+		return
+	}
+	err := svc.PutProviderLocations(observability.WithIngestTransport(r.Context(), "http"), body)
+	writeAcceptedOrError(w, err)
+}
+
+func (h *Handler) DeleteProviderLocations(w http.ResponseWriter, r *http.Request) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "delete provider locations is not implemented")
+		return
+	}
+	err := svc.DeleteProviderLocations(r.Context())
+	writeNoContentOrError(w, err)
 }
 
 func (h *Handler) PostProviderProximities(w http.ResponseWriter, r *http.Request) {
@@ -188,9 +410,130 @@ func (h *Handler) PostProviderProximities(w http.ResponseWriter, r *http.Request
 	writeAcceptedOrError(w, err)
 }
 
+func (h *Handler) PutProviderProximities(w http.ResponseWriter, r *http.Request) {
+	var body []gen.Proximity
+	if err := decodeJSONBody(w, r, h.deps.RequestBodyLimitBytes, &body); err != nil {
+		writeJSONOrError(w, nil, err, 0)
+		return
+	}
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "bulk provider proximity replace is not implemented")
+		return
+	}
+	err := svc.PutProviderProximities(observability.WithIngestTransport(r.Context(), "http"), body)
+	writeAcceptedOrError(w, err)
+}
+
+func (h *Handler) GetProviderFences(w http.ResponseWriter, r *http.Request, id gen.ProviderId) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "provider fences are not implemented")
+		return
+	}
+	items, err := svc.ListProviderFences(r.Context(), id)
+	writeJSONOrError(w, items, err, http.StatusOK)
+}
+
+func (h *Handler) GetProviderLocation(w http.ResponseWriter, r *http.Request, id gen.ProviderId) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "provider location is not implemented")
+		return
+	}
+	item, err := svc.GetProviderLocation(r.Context(), id)
+	writeJSONOrError(w, item, err, http.StatusOK)
+}
+
+func (h *Handler) PutProviderLocation(w http.ResponseWriter, r *http.Request, id gen.ProviderId) {
+	var body gen.Location
+	if err := decodeJSONBody(w, r, h.deps.RequestBodyLimitBytes, &body); err != nil {
+		writeJSONOrError(w, nil, err, 0)
+		return
+	}
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "single provider location update is not implemented")
+		return
+	}
+	err := svc.PutProviderLocation(observability.WithIngestTransport(r.Context(), "http"), id, body)
+	writeAcceptedOrError(w, err)
+}
+
+func (h *Handler) DeleteProviderLocation(w http.ResponseWriter, r *http.Request, id gen.ProviderId) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "delete provider location is not implemented")
+		return
+	}
+	err := svc.DeleteProviderLocation(r.Context(), id)
+	writeNoContentOrError(w, err)
+}
+
+func (h *Handler) PutProviderProximity(w http.ResponseWriter, r *http.Request, id gen.ProviderId) {
+	var body gen.Proximity
+	if err := decodeJSONBody(w, r, h.deps.RequestBodyLimitBytes, &body); err != nil {
+		writeJSONOrError(w, nil, err, 0)
+		return
+	}
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "single provider proximity update is not implemented")
+		return
+	}
+	err := svc.PutProviderProximity(observability.WithIngestTransport(r.Context(), "http"), id, body)
+	writeAcceptedOrError(w, err)
+}
+
+func (h *Handler) GetProviderSensors(w http.ResponseWriter, r *http.Request, id gen.ProviderId) {
+	provider, err := h.deps.Service.GetProvider(r.Context(), id)
+	if err != nil {
+		writeJSONOrError(w, nil, err, 0)
+		return
+	}
+	if provider.Sensors == nil {
+		writeJSONOrError(w, map[string]any{}, nil, http.StatusOK)
+		return
+	}
+	writeJSONOrError(w, *provider.Sensors, nil, http.StatusOK)
+}
+
+func (h *Handler) PutProviderSensors(w http.ResponseWriter, r *http.Request, id gen.ProviderId) {
+	var body map[string]any
+	if err := decodeJSONBody(w, r, h.deps.RequestBodyLimitBytes, &body); err != nil {
+		writeJSONOrError(w, nil, err, 0)
+		return
+	}
+	provider, err := h.deps.Service.GetProvider(r.Context(), id)
+	if err != nil {
+		writeJSONOrError(w, nil, err, 0)
+		return
+	}
+	props := gen.ExtensionProperties(body)
+	writeBody := gen.LocationProviderWrite(provider)
+	writeBody.Sensors = &props
+	item, err := h.deps.Service.UpdateProvider(r.Context(), id, writeBody)
+	writeJSONOrError(w, item, err, http.StatusOK)
+}
+
 func (h *Handler) ListFences(w http.ResponseWriter, r *http.Request) {
 	items, err := h.deps.Service.ListFences(r.Context())
 	writeJSONOrError(w, items, err, http.StatusOK)
+}
+
+func (h *Handler) DeleteFences(w http.ResponseWriter, r *http.Request) {
+	items, err := h.deps.Service.ListFences(r.Context())
+	if err != nil {
+		writeJSONOrError(w, nil, err, 0)
+		return
+	}
+	for _, item := range items {
+		if err := h.deps.Service.DeleteFence(r.Context(), item.Id); err != nil {
+			writeJSONOrError(w, nil, err, 0)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) CreateFence(w http.ResponseWriter, r *http.Request) {
@@ -221,6 +564,31 @@ func (h *Handler) UpdateFence(w http.ResponseWriter, r *http.Request, id gen.Fen
 func (h *Handler) DeleteFence(w http.ResponseWriter, r *http.Request, id gen.FenceId) {
 	err := h.deps.Service.DeleteFence(r.Context(), id)
 	writeNoContentOrError(w, err)
+}
+
+func (h *Handler) GetFencesSummary(w http.ResponseWriter, r *http.Request) {
+	items, err := h.deps.Service.ListFences(r.Context())
+	writeJSONOrError(w, summaryResponse("fences", len(items)), err, http.StatusOK)
+}
+
+func (h *Handler) GetFenceProviders(w http.ResponseWriter, r *http.Request, id gen.FenceId) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "fence providers are not implemented")
+		return
+	}
+	items, err := svc.ListFenceProviders(r.Context(), id)
+	writeJSONOrError(w, items, err, http.StatusOK)
+}
+
+func (h *Handler) GetFenceLocations(w http.ResponseWriter, r *http.Request, id gen.FenceId) {
+	svc, ok := h.extendedService()
+	if !ok {
+		writeStubNotImplemented(w, "fence locations are not implemented")
+		return
+	}
+	items, err := svc.ListFenceLocations(r.Context(), id)
+	writeJSONOrError(w, items, err, http.StatusOK)
 }
 
 func (h *Handler) GetRPCAvailable(w http.ResponseWriter, r *http.Request) {
@@ -337,5 +705,25 @@ func writeJSONOrError(w http.ResponseWriter, payload any, err error, successStat
 	w.WriteHeader(successStatus)
 	if payload != nil {
 		_ = json.NewEncoder(w).Encode(payload)
+	}
+}
+
+func writeStubNotImplemented(w http.ResponseWriter, message string) {
+	writeJSONOrError(w, nil, &hub.HTTPError{
+		Status:  http.StatusNotImplemented,
+		Type:    "not_implemented",
+		Message: message,
+	}, 0)
+}
+
+func (h *Handler) extendedService() (extendedService, bool) {
+	svc, ok := h.deps.Service.(extendedService)
+	return svc, ok
+}
+
+func summaryResponse(kind string, count int) map[string]any {
+	return map[string]any{
+		"type":  kind,
+		"count": count,
 	}
 }

--- a/internal/httpapi/handlers/handlers_test.go
+++ b/internal/httpapi/handlers/handlers_test.go
@@ -292,6 +292,65 @@ func TestHandlerDirectBodiesCoverRawAndTypedEndpoints(t *testing.T) {
 	}
 }
 
+func TestHandlerStubbedOmloxRoutesReturnNotImplemented(t *testing.T) {
+	t.Parallel()
+
+	zoneID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	trackableID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	fenceID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+
+	handler := newTestServer(&fakeService{}, &fakeRPC{})
+	tests := []struct {
+		method string
+		path   string
+		body   string
+		status int
+	}{
+		{method: http.MethodDelete, path: "/v2/zones", status: http.StatusNoContent},
+		{method: http.MethodGet, path: "/v2/zones/summary", status: http.StatusOK},
+		{method: http.MethodPut, path: "/v2/zones/" + zoneID.String() + "/transform", body: `{}`, status: http.StatusNotImplemented},
+		{method: http.MethodGet, path: "/v2/zones/" + zoneID.String() + "/createfence", status: http.StatusNotImplemented},
+		{method: http.MethodDelete, path: "/v2/trackables", status: http.StatusNoContent},
+		{method: http.MethodGet, path: "/v2/trackables/summary", status: http.StatusOK},
+		{method: http.MethodGet, path: "/v2/trackables/motions", status: http.StatusNotImplemented},
+		{method: http.MethodGet, path: "/v2/trackables/" + trackableID.String() + "/fences", status: http.StatusNotImplemented},
+		{method: http.MethodGet, path: "/v2/trackables/" + trackableID.String() + "/location", status: http.StatusNotImplemented},
+		{method: http.MethodGet, path: "/v2/trackables/" + trackableID.String() + "/locations", status: http.StatusNotImplemented},
+		{method: http.MethodGet, path: "/v2/trackables/" + trackableID.String() + "/motion", status: http.StatusNotImplemented},
+		{method: http.MethodGet, path: "/v2/trackables/" + trackableID.String() + "/providers", status: http.StatusNotImplemented},
+		{method: http.MethodGet, path: "/v2/trackables/" + trackableID.String() + "/sensors", status: http.StatusNotImplemented},
+		{method: http.MethodDelete, path: "/v2/providers", status: http.StatusNoContent},
+		{method: http.MethodGet, path: "/v2/providers/summary", status: http.StatusOK},
+		{method: http.MethodGet, path: "/v2/providers/locations", status: http.StatusNotImplemented},
+		{method: http.MethodPut, path: "/v2/providers/locations", body: `[]`, status: http.StatusNotImplemented},
+		{method: http.MethodDelete, path: "/v2/providers/locations", status: http.StatusNotImplemented},
+		{method: http.MethodPut, path: "/v2/providers/proximities", body: `[]`, status: http.StatusNotImplemented},
+		{method: http.MethodGet, path: "/v2/providers/provider-a/fences", status: http.StatusNotImplemented},
+		{method: http.MethodGet, path: "/v2/providers/provider-a/location", status: http.StatusNotImplemented},
+		{method: http.MethodPut, path: "/v2/providers/provider-a/location", body: `{}`, status: http.StatusNotImplemented},
+		{method: http.MethodDelete, path: "/v2/providers/provider-a/location", status: http.StatusNotImplemented},
+		{method: http.MethodPut, path: "/v2/providers/provider-a/proximity", body: `{}`, status: http.StatusNotImplemented},
+		{method: http.MethodGet, path: "/v2/providers/provider-a/sensors", status: http.StatusOK},
+		{method: http.MethodPut, path: "/v2/providers/provider-a/sensors", body: `{}`, status: http.StatusOK},
+		{method: http.MethodDelete, path: "/v2/fences", status: http.StatusNoContent},
+		{method: http.MethodGet, path: "/v2/fences/summary", status: http.StatusOK},
+		{method: http.MethodGet, path: "/v2/fences/" + fenceID.String() + "/providers", status: http.StatusNotImplemented},
+		{method: http.MethodGet, path: "/v2/fences/" + fenceID.String() + "/locations", status: http.StatusNotImplemented},
+	}
+
+	for _, tc := range tests {
+		req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != tc.status {
+			t.Fatalf("%s %s: got %d want %d body=%s", tc.method, tc.path, rec.Code, tc.status, rec.Body.String())
+		}
+		if tc.status == http.StatusNotImplemented && !strings.Contains(rec.Body.String(), `"type":"not_implemented"`) {
+			t.Fatalf("%s %s: expected not_implemented body, got %s", tc.method, tc.path, rec.Body.String())
+		}
+	}
+}
+
 func TestDecodeJSONBodyAcceptsSingleDocument(t *testing.T) {
 	t.Parallel()
 
@@ -382,69 +441,135 @@ type fakeService struct {
 }
 
 func (f *fakeService) ListZones(ctx context.Context) ([]gen.Zone, error) {
+	if f.listZonesFn == nil {
+		return nil, nil
+	}
 	return f.listZonesFn(ctx)
 }
 func (f *fakeService) CreateZone(ctx context.Context, body json.RawMessage) (gen.Zone, error) {
+	if f.createZoneFn == nil {
+		return gen.Zone{}, nil
+	}
 	return f.createZoneFn(ctx, body)
 }
 func (f *fakeService) GetZone(ctx context.Context, id gen.ZoneId) (gen.Zone, error) {
+	if f.getZoneFn == nil {
+		return gen.Zone{}, nil
+	}
 	return f.getZoneFn(ctx, id)
 }
 func (f *fakeService) UpdateZone(ctx context.Context, id gen.ZoneId, body json.RawMessage) (gen.Zone, error) {
+	if f.updateZoneFn == nil {
+		return gen.Zone{}, nil
+	}
 	return f.updateZoneFn(ctx, id, body)
 }
 func (f *fakeService) DeleteZone(ctx context.Context, id gen.ZoneId) error {
+	if f.deleteZoneFn == nil {
+		return nil
+	}
 	return f.deleteZoneFn(ctx, id)
 }
 func (f *fakeService) ListTrackables(ctx context.Context) ([]gen.Trackable, error) {
+	if f.listTrackablesFn == nil {
+		return nil, nil
+	}
 	return f.listTrackablesFn(ctx)
 }
 func (f *fakeService) CreateTrackable(ctx context.Context, body gen.TrackableWrite) (gen.Trackable, error) {
+	if f.createTrackableFn == nil {
+		return gen.Trackable{}, nil
+	}
 	return f.createTrackableFn(ctx, body)
 }
 func (f *fakeService) GetTrackable(ctx context.Context, id gen.TrackableId) (gen.Trackable, error) {
+	if f.getTrackableFn == nil {
+		return gen.Trackable{}, nil
+	}
 	return f.getTrackableFn(ctx, id)
 }
 func (f *fakeService) UpdateTrackable(ctx context.Context, id gen.TrackableId, body gen.TrackableWrite) (gen.Trackable, error) {
+	if f.updateTrackableFn == nil {
+		return gen.Trackable{}, nil
+	}
 	return f.updateTrackableFn(ctx, id, body)
 }
 func (f *fakeService) DeleteTrackable(ctx context.Context, id gen.TrackableId) error {
+	if f.deleteTrackableFn == nil {
+		return nil
+	}
 	return f.deleteTrackableFn(ctx, id)
 }
 func (f *fakeService) ListProviders(ctx context.Context) ([]gen.LocationProvider, error) {
+	if f.listProvidersFn == nil {
+		return nil, nil
+	}
 	return f.listProvidersFn(ctx)
 }
 func (f *fakeService) CreateProvider(ctx context.Context, body gen.LocationProviderWrite) (gen.LocationProvider, error) {
+	if f.createProviderFn == nil {
+		return gen.LocationProvider{}, nil
+	}
 	return f.createProviderFn(ctx, body)
 }
 func (f *fakeService) GetProvider(ctx context.Context, id gen.ProviderId) (gen.LocationProvider, error) {
+	if f.getProviderFn == nil {
+		return gen.LocationProvider{}, nil
+	}
 	return f.getProviderFn(ctx, id)
 }
 func (f *fakeService) UpdateProvider(ctx context.Context, id gen.ProviderId, body gen.LocationProviderWrite) (gen.LocationProvider, error) {
+	if f.updateProviderFn == nil {
+		return gen.LocationProvider{}, nil
+	}
 	return f.updateProviderFn(ctx, id, body)
 }
 func (f *fakeService) DeleteProvider(ctx context.Context, id gen.ProviderId) error {
+	if f.deleteProviderFn == nil {
+		return nil
+	}
 	return f.deleteProviderFn(ctx, id)
 }
 func (f *fakeService) ProcessLocations(ctx context.Context, locations []gen.Location) error {
+	if f.processLocationsFn == nil {
+		return nil
+	}
 	return f.processLocationsFn(ctx, locations)
 }
 func (f *fakeService) ProcessProximities(ctx context.Context, proximities []gen.Proximity) error {
+	if f.processProximitiesFn == nil {
+		return nil
+	}
 	return f.processProximitiesFn(ctx, proximities)
 }
 func (f *fakeService) ListFences(ctx context.Context) ([]gen.Fence, error) {
+	if f.listFencesFn == nil {
+		return nil, nil
+	}
 	return f.listFencesFn(ctx)
 }
 func (f *fakeService) CreateFence(ctx context.Context, body json.RawMessage) (gen.Fence, error) {
+	if f.createFenceFn == nil {
+		return gen.Fence{}, nil
+	}
 	return f.createFenceFn(ctx, body)
 }
 func (f *fakeService) GetFence(ctx context.Context, id gen.FenceId) (gen.Fence, error) {
+	if f.getFenceFn == nil {
+		return gen.Fence{}, nil
+	}
 	return f.getFenceFn(ctx, id)
 }
 func (f *fakeService) UpdateFence(ctx context.Context, id gen.FenceId, body json.RawMessage) (gen.Fence, error) {
+	if f.updateFenceFn == nil {
+		return gen.Fence{}, nil
+	}
 	return f.updateFenceFn(ctx, id, body)
 }
 func (f *fakeService) DeleteFence(ctx context.Context, id gen.FenceId) error {
+	if f.deleteFenceFn == nil {
+		return nil
+	}
 	return f.deleteFenceFn(ctx, id)
 }
 
@@ -454,10 +579,16 @@ type fakeRPC struct {
 }
 
 func (f *fakeRPC) AvailableMethods(ctx context.Context) (gen.RpcAvailableMethods, error) {
+	if f.availableMethodsFn == nil {
+		return nil, nil
+	}
 	return f.availableMethodsFn(ctx)
 }
 
 func (f *fakeRPC) Invoke(ctx context.Context, request gen.JsonRpcRequest) (json.RawMessage, bool, error) {
+	if f.invokeFn == nil {
+		return nil, false, nil
+	}
 	return f.invokeFn(ctx, request)
 }
 

--- a/internal/hub/processing_state.go
+++ b/internal/hub/processing_state.go
@@ -92,10 +92,74 @@ func (s *ProcessingState) SetLatestLocation(key string, value gen.Location, ttl 
 	s.latestLocations[key] = expiringLocation{value: value, expiresAt: s.nowUTC().Add(ttl)}
 }
 
+func (s *ProcessingState) GetLatestLocation(key string) (gen.Location, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item, ok := s.latestLocations[key]
+	if !ok || !item.expiresAt.After(s.nowUTC()) {
+		delete(s.latestLocations, key)
+		return gen.Location{}, false
+	}
+	return item.value, true
+}
+
+func (s *ProcessingState) DeleteLatestLocation(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.latestLocations, key)
+}
+
+func (s *ProcessingState) ListLatestLocations() []gen.Location {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.nowUTC()
+	locations := make([]gen.Location, 0, len(s.latestLocations))
+	for key, item := range s.latestLocations {
+		if !item.expiresAt.After(now) {
+			delete(s.latestLocations, key)
+			continue
+		}
+		locations = append(locations, item.value)
+	}
+	return locations
+}
+
 func (s *ProcessingState) SetTrackableLocation(key string, value gen.Location, ttl time.Duration) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.latestTrackableLocation[key] = expiringLocation{value: value, expiresAt: s.nowUTC().Add(ttl)}
+}
+
+func (s *ProcessingState) GetTrackableLocation(key string) (gen.Location, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item, ok := s.latestTrackableLocation[key]
+	if !ok || !item.expiresAt.After(s.nowUTC()) {
+		delete(s.latestTrackableLocation, key)
+		return gen.Location{}, false
+	}
+	return item.value, true
+}
+
+func (s *ProcessingState) DeleteTrackableLocation(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.latestTrackableLocation, key)
+}
+
+func (s *ProcessingState) ListTrackableLocations() []gen.Location {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.nowUTC()
+	locations := make([]gen.Location, 0, len(s.latestTrackableLocation))
+	for key, item := range s.latestTrackableLocation {
+		if !item.expiresAt.After(now) {
+			delete(s.latestTrackableLocation, key)
+			continue
+		}
+		locations = append(locations, item.value)
+	}
+	return locations
 }
 
 func (s *ProcessingState) GetProximityState(key string) (proximityResolutionState, bool) {

--- a/internal/hub/service.go
+++ b/internal/hub/service.go
@@ -407,6 +407,113 @@ func (s *Service) DeleteZone(ctx context.Context, id openapi_types.UUID) error {
 	return nil
 }
 
+// GetZoneCreateFence derives an approximate fence from an existing zone.
+func (s *Service) GetZoneCreateFence(ctx context.Context, id openapi_types.UUID) (gen.Fence, error) {
+	zone, err := s.GetZone(ctx, id)
+	if err != nil {
+		return gen.Fence{}, err
+	}
+	if zone.Position != nil {
+		var region gen.Fence_Region
+		if err := region.FromPoint(*zone.Position); err != nil {
+			return gen.Fence{}, err
+		}
+		fence := gen.Fence{
+			Id:     ids.NewUUID(),
+			Region: region,
+			Radius: zone.Radius,
+			Name:   zone.Name,
+		}
+		epsg := gen.FenceElevationRefFloor
+		fence.ElevationRef = &epsg
+		if zone.Type != "rfid" && zone.Type != "ibeacon" {
+			crs := "EPSG:4326"
+			fence.Crs = &crs
+		}
+		return fence, nil
+	}
+	if zone.GroundControlPoints != nil && len(*zone.GroundControlPoints) >= 3 {
+		ring := make([]gen.GeoJsonPosition, 0, len(*zone.GroundControlPoints)+1)
+		for _, gcp := range *zone.GroundControlPoints {
+			local, err := gcp.Local.Coordinates.AsGeoJsonPosition2D()
+			if err != nil {
+				return gen.Fence{}, badRequest("zone ground_control_points contained invalid local coordinates")
+			}
+			var position gen.GeoJsonPosition
+			if err := position.FromGeoJsonPosition2D(gen.GeoJsonPosition2D{local[0], local[1]}); err != nil {
+				return gen.Fence{}, err
+			}
+			ring = append(ring, position)
+		}
+		ring = append(ring, ring[0])
+		polygon := gen.Polygon{
+			Type:        "Polygon",
+			Coordinates: [][]gen.GeoJsonPosition{ring},
+		}
+		var region gen.Fence_Region
+		if err := region.FromPolygon(polygon); err != nil {
+			return gen.Fence{}, err
+		}
+		fence := gen.Fence{
+			Id:     ids.NewUUID(),
+			Region: region,
+			Name:   zone.Name,
+		}
+		localCRS := "local"
+		fence.Crs = &localCRS
+		elevationRef := gen.FenceElevationRefFloor
+		fence.ElevationRef = &elevationRef
+		zoneID := zone.Id.String()
+		fence.ZoneId = &zoneID
+		return fence, nil
+	}
+	return gen.Fence{}, badRequest("zone could not be approximated as a fence")
+}
+
+// PutZoneTransform transforms a point between local and WGS84 for a zone.
+func (s *Service) PutZoneTransform(ctx context.Context, id openapi_types.UUID, body json.RawMessage) (map[string]any, error) {
+	var request struct {
+		Position gen.Point `json:"position"`
+		Crs      string    `json:"crs"`
+	}
+	if err := json.Unmarshal(body, &request); err != nil {
+		return nil, badRequest("invalid transform payload")
+	}
+	if request.Position.Type != "Point" {
+		return nil, badRequest("transform payload requires a GeoJSON Point")
+	}
+	source := id.String()
+	location := gen.Location{
+		ProviderId:   "zone-transform",
+		ProviderType: "zone-transform",
+		Source:       source,
+		Position:     request.Position,
+	}
+	inputCRS := strings.TrimSpace(request.Crs)
+	if inputCRS == "" {
+		inputCRS = "local"
+	}
+	location.Crs = &inputCRS
+	var transformed gen.Location
+	var err error
+	switch inputCRS {
+	case "local":
+		transformed, err = s.locationToWGS84(ctx, location)
+	case "EPSG:4326":
+		transformed, err = s.locationToLocal(ctx, location)
+	default:
+		return nil, badRequest("transform crs must be local or EPSG:4326")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"position": transformed.Position,
+		"crs":      strings.TrimSpace(locationCRS(transformed)),
+		"zone_id":  source,
+	}, nil
+}
+
 // ListProviders returns all location providers known to the hub.
 func (s *Service) ListProviders(ctx context.Context) ([]gen.LocationProvider, error) {
 	if cache := s.metadataCache(); cache != nil {
@@ -521,6 +628,78 @@ func (s *Service) DeleteProvider(ctx context.Context, id string) error {
 		Timestamp: s.now().UTC(),
 	})
 	return nil
+}
+
+// ListProviderLocations returns the active latest locations held in memory.
+func (s *Service) ListProviderLocations(_ context.Context) ([]gen.Location, error) {
+	locations := s.processingState().ListLatestLocations()
+	sort.Slice(locations, func(i, j int) bool {
+		return locationTime(locations[i]).After(locationTime(locations[j]))
+	})
+	return locations, nil
+}
+
+// GetProviderLocation returns the latest location known for a provider.
+func (s *Service) GetProviderLocation(ctx context.Context, id string) (gen.Location, error) {
+	if _, ok := s.providerByID(ctx, id); !ok {
+		return gen.Location{}, notFound("provider not found")
+	}
+	location, ok := latestLocationForProvider(s.processingState().ListLatestLocations(), id)
+	if !ok {
+		return gen.Location{}, notFound("provider location not found")
+	}
+	return location, nil
+}
+
+// PutProviderLocation validates and processes a single provider location update.
+func (s *Service) PutProviderLocation(ctx context.Context, id string, location gen.Location) error {
+	location.ProviderId = id
+	return s.ProcessLocations(ctx, []gen.Location{location})
+}
+
+// DeleteProviderLocation clears the active latest location state for a provider.
+func (s *Service) DeleteProviderLocation(ctx context.Context, id string) error {
+	if _, ok := s.providerByID(ctx, id); !ok {
+		return notFound("provider not found")
+	}
+	removed := s.deleteProviderState(ctx, id)
+	if !removed {
+		return notFound("provider location not found")
+	}
+	return nil
+}
+
+// DeleteProviderLocations clears all active latest provider location state.
+func (s *Service) DeleteProviderLocations(_ context.Context) error {
+	for _, location := range s.processingState().ListLatestLocations() {
+		_ = s.deleteProviderState(context.Background(), location.ProviderId)
+	}
+	return nil
+}
+
+// PutProviderLocations validates and processes a batch of provider locations.
+func (s *Service) PutProviderLocations(ctx context.Context, locations []gen.Location) error {
+	return s.ProcessLocations(ctx, locations)
+}
+
+// PutProviderProximity validates and processes a single proximity update.
+func (s *Service) PutProviderProximity(ctx context.Context, id string, proximity gen.Proximity) error {
+	proximity.ProviderId = id
+	return s.ProcessProximities(ctx, []gen.Proximity{proximity})
+}
+
+// PutProviderProximities validates and processes a batch of proximity updates.
+func (s *Service) PutProviderProximities(ctx context.Context, proximities []gen.Proximity) error {
+	return s.ProcessProximities(ctx, proximities)
+}
+
+// ListProviderFences returns the fences currently containing the provider's latest location.
+func (s *Service) ListProviderFences(ctx context.Context, id string) ([]gen.Fence, error) {
+	location, err := s.GetProviderLocation(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return s.fencesForLocation(ctx, location)
 }
 
 // ListTrackables returns all trackables known to the hub.
@@ -639,6 +818,94 @@ func (s *Service) DeleteTrackable(ctx context.Context, id openapi_types.UUID) er
 	return nil
 }
 
+// GetTrackableLocation returns the latest derived location known for a trackable.
+func (s *Service) GetTrackableLocation(ctx context.Context, id openapi_types.UUID) (gen.Location, error) {
+	if _, err := s.GetTrackable(ctx, id); err != nil {
+		return gen.Location{}, err
+	}
+	location, ok := s.processingState().GetTrackableLocation(latestTrackableLocationKey(id.String()))
+	if !ok {
+		return gen.Location{}, notFound("trackable location not found")
+	}
+	return location, nil
+}
+
+// ListTrackableLocations returns the latest provider locations associated to a trackable.
+func (s *Service) ListTrackableLocations(ctx context.Context, id openapi_types.UUID) ([]gen.Location, error) {
+	trackable, err := s.GetTrackable(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	providerSet := make(map[string]struct{}, len(stringSliceValue(trackable.LocationProviders)))
+	for _, providerID := range stringSliceValue(trackable.LocationProviders) {
+		providerSet[providerID] = struct{}{}
+	}
+	locations := s.processingState().ListLatestLocations()
+	filtered := make([]gen.Location, 0, len(locations))
+	for _, location := range locations {
+		if _, ok := providerSet[location.ProviderId]; ok || locationAssociatedWithTrackable(location, id.String()) {
+			filtered = append(filtered, location)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		return locationTime(filtered[i]).After(locationTime(filtered[j]))
+	})
+	return filtered, nil
+}
+
+// GetTrackableMotion returns the latest derived motion known for a trackable.
+func (s *Service) GetTrackableMotion(ctx context.Context, id openapi_types.UUID) (gen.TrackableMotion, error) {
+	if _, err := s.GetTrackable(ctx, id); err != nil {
+		return gen.TrackableMotion{}, err
+	}
+	motion, ok := s.processingState().GetMotion(id.String())
+	if !ok {
+		return gen.TrackableMotion{}, notFound("trackable motion not found")
+	}
+	return motion, nil
+}
+
+// ListTrackableMotions returns all active trackable motions held in memory.
+func (s *Service) ListTrackableMotions(_ context.Context) ([]gen.TrackableMotion, error) {
+	motions := s.processingState().ListActiveMotions()
+	sort.Slice(motions, func(i, j int) bool {
+		return locationTime(motions[i].Location).After(locationTime(motions[j].Location))
+	})
+	return motions, nil
+}
+
+// ListTrackableFences returns the fences currently containing the trackable.
+func (s *Service) ListTrackableFences(ctx context.Context, id openapi_types.UUID) ([]gen.Fence, error) {
+	if _, err := s.GetTrackable(ctx, id); err != nil {
+		return nil, err
+	}
+	activeFenceIDs := s.processingState().ListInsideFences(id.String())
+	fences := make([]gen.Fence, 0, len(activeFenceIDs))
+	for _, fenceID := range activeFenceIDs {
+		fence, ok := s.fenceByID(ctx, fenceID)
+		if ok {
+			fences = append(fences, fence)
+		}
+	}
+	return fences, nil
+}
+
+// ListTrackableProviders returns the providers assigned to a trackable.
+func (s *Service) ListTrackableProviders(ctx context.Context, id openapi_types.UUID) ([]gen.LocationProvider, error) {
+	trackable, err := s.GetTrackable(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	providers := make([]gen.LocationProvider, 0, len(stringSliceValue(trackable.LocationProviders)))
+	for _, providerID := range stringSliceValue(trackable.LocationProviders) {
+		provider, ok := s.providerByID(ctx, providerID)
+		if ok {
+			providers = append(providers, provider)
+		}
+	}
+	return providers, nil
+}
+
 // ListFences returns all fences known to the hub.
 func (s *Service) ListFences(ctx context.Context) ([]gen.Fence, error) {
 	if cache := s.metadataCache(); cache != nil {
@@ -753,6 +1020,47 @@ func (s *Service) DeleteFence(ctx context.Context, id openapi_types.UUID) error 
 		Timestamp: s.now().UTC(),
 	})
 	return nil
+}
+
+// ListFenceLocations returns active latest locations currently inside a fence.
+func (s *Service) ListFenceLocations(ctx context.Context, id openapi_types.UUID) ([]gen.Location, error) {
+	fence, err := s.GetFence(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	locations := s.processingState().ListLatestLocations()
+	filtered := make([]gen.Location, 0, len(locations))
+	for _, location := range locations {
+		if fenceContainsLocation(fence, location) {
+			filtered = append(filtered, location)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		return locationTime(filtered[i]).After(locationTime(filtered[j]))
+	})
+	return filtered, nil
+}
+
+// ListFenceProviders returns providers with active latest locations inside a fence.
+func (s *Service) ListFenceProviders(ctx context.Context, id openapi_types.UUID) ([]gen.LocationProvider, error) {
+	locations, err := s.ListFenceLocations(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]struct{}{}
+	providers := make([]gen.LocationProvider, 0, len(locations))
+	for _, location := range locations {
+		if _, ok := seen[location.ProviderId]; ok {
+			continue
+		}
+		provider, ok := s.providerByID(ctx, location.ProviderId)
+		if !ok {
+			continue
+		}
+		seen[location.ProviderId] = struct{}{}
+		providers = append(providers, provider)
+	}
+	return providers, nil
 }
 
 // ProcessLocations validates, stores, and republishes provider location
@@ -2652,6 +2960,79 @@ func latestLocationKey(providerID, source string) string {
 
 func latestTrackableLocationKey(trackableID string) string {
 	return fmt.Sprintf("hub:trackable:%s:location", trackableID)
+}
+
+func latestLocationForProvider(locations []gen.Location, providerID string) (gen.Location, bool) {
+	var latest gen.Location
+	found := false
+	for _, location := range locations {
+		if location.ProviderId != providerID {
+			continue
+		}
+		if !found || locationTime(location).After(locationTime(latest)) {
+			latest = location
+			found = true
+		}
+	}
+	return latest, found
+}
+
+func locationAssociatedWithTrackable(location gen.Location, trackableID string) bool {
+	if location.Trackables == nil {
+		return false
+	}
+	for _, id := range *location.Trackables {
+		if id == trackableID {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) deleteProviderState(ctx context.Context, providerID string) bool {
+	removed := false
+	for _, location := range s.processingState().ListLatestLocations() {
+		if location.ProviderId != providerID {
+			continue
+		}
+		removed = true
+		s.processingState().DeleteLatestLocation(latestLocationKey(location.ProviderId, location.Source))
+		for _, trackableID := range stringSliceValue(location.Trackables) {
+			s.processingState().DeleteTrackableLocation(latestTrackableLocationKey(trackableID))
+			s.processingState().DeleteMotion(trackableID)
+			for _, fenceID := range s.processingState().ListInsideFences(trackableID) {
+				s.processingState().ClearInsideFence(trackableID, fenceID)
+			}
+		}
+	}
+	return removed
+}
+
+func (s *Service) fencesForLocation(ctx context.Context, location gen.Location) ([]gen.Fence, error) {
+	fences, err := s.fenceCandidatesForLocation(ctx, location)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]gen.Fence, 0, len(fences))
+	for _, fence := range fences {
+		if !fenceContainsLocation(fence, location) {
+			continue
+		}
+		out = append(out, fence)
+	}
+	return out, nil
+}
+
+func fenceContainsLocation(fence gen.Fence, location gen.Location) bool {
+	if !fenceMatchesFloor(fence, location) {
+		return false
+	}
+	point, err := point2D(location.Position)
+	if err != nil {
+		return false
+	}
+	inside, err := fenceContainsPoint(fence, point)
+	return err == nil && inside
 }
 
 func proximityResolutionStateKey(providerType, providerID string) string {

--- a/specifications/omlox/location-providers.md
+++ b/specifications/omlox/location-providers.md
@@ -43,4 +43,16 @@ Current repository behavior for proximity ingestion:
 - per-zone tuning comes from `Zone.properties.proximity_resolution`
 
 ### Inferred resource lifecycle operations
-The Location Provider API is defined as setup + update advertisement API; companion OpenAPI is expected to define provider management endpoints under `/v2/providers` and `/v2/providers/{providerId}`.
+The Location Provider API is defined as setup + update advertisement API. The companion OpenAPI surface used in this repository now includes:
+- `/v2/providers`
+- `/v2/providers/summary`
+- `/v2/providers/locations`
+- `/v2/providers/proximities`
+- `/v2/providers/{providerId}`
+- `/v2/providers/{providerId}/fences`
+- `/v2/providers/{providerId}/location`
+- `/v2/providers/{providerId}/proximity`
+- `/v2/providers/{providerId}/sensors`
+
+Current repository contract status:
+- CRUD, summaries, bulk and per-provider ingest, nested provider reads, sensor updates, and collection delete routes are implemented.

--- a/specifications/omlox/trackables.md
+++ b/specifications/omlox/trackables.md
@@ -29,7 +29,20 @@ Key fields from section 6.7.13:
 ## Operations
 
 ### Inferred resource lifecycle operations
-Trackable API is defined as a management API; companion OpenAPI is expected to define CRUD endpoints under `/v2/trackables` and `/v2/trackables/{trackableId}`.
+Trackable API is defined as a management API. The companion OpenAPI surface used in this repository now includes:
+- `/v2/trackables`
+- `/v2/trackables/summary`
+- `/v2/trackables/motions`
+- `/v2/trackables/{trackableId}`
+- `/v2/trackables/{trackableId}/fences`
+- `/v2/trackables/{trackableId}/location`
+- `/v2/trackables/{trackableId}/locations`
+- `/v2/trackables/{trackableId}/motion`
+- `/v2/trackables/{trackableId}/providers`
+- `/v2/trackables/{trackableId}/sensors`
+
+Current repository contract status:
+- CRUD, summary, motion, nested read endpoints, and collection delete are implemented.
 
 ## Behavioral requirements
 

--- a/specifications/omlox/zones.md
+++ b/specifications/omlox/zones.md
@@ -34,7 +34,15 @@ Used for both:
 - initialized zone announcement (complete required fields)
 
 ### Inferred resource lifecycle operations
-The Zone API is defined as setup/management API. In the companion OpenAPI this typically includes list/read/update/delete forms for `/v2/zones` and `/v2/zones/{zoneId}`.
+The Zone API is defined as setup/management API. The companion OpenAPI surface used in this repository now includes:
+- `/v2/zones`
+- `/v2/zones/summary`
+- `/v2/zones/{zoneId}`
+- `/v2/zones/{zoneId}/transform`
+- `/v2/zones/{zoneId}/createfence`
+
+Current repository contract status:
+- CRUD, summary, transform, collection delete, and fence derivation routes are implemented.
 
 ## Behavioral requirements
 

--- a/specifications/openapi/omlox-hub.v0.yaml
+++ b/specifications/openapi/omlox-hub.v0.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Open Location Hub API
-  version: 0.1.5
+  version: 0.1.6
   description: |
     REST API documentation for Open Location Hub.
 
@@ -53,6 +53,18 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+    delete:
+      tags: [zones]
+      operationId: deleteZones
+      summary: Delete all zones
+      description: Removes all zones known to the hub.
+      responses:
+        '204':
+          description: Deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
     post:
       tags: [zones]
       operationId: createZone
@@ -76,6 +88,23 @@ paths:
                 $ref: '#/components/schemas/Zone'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/zones/summary:
+    get:
+      tags: [zones]
+      operationId: getZonesSummary
+      summary: Get zone summary
+      description: Returns a compact count of zones known to the hub.
+      responses:
+        '200':
+          description: Zone summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceSummary'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -141,6 +170,68 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /v2/zones/{zoneId}/transform:
+    parameters:
+      - $ref: '#/components/parameters/ZoneId'
+    put:
+      tags: [zones]
+      operationId: putZoneTransform
+      summary: Update zone transform
+      description: Transforms a point between zone-local coordinates and WGS84.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: Transformed point
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [position, crs, zone_id]
+                properties:
+                  position:
+                    $ref: '#/components/schemas/Point'
+                  crs:
+                    type: string
+                  zone_id:
+                    type: string
+                    format: uuid
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/zones/{zoneId}/createfence:
+    parameters:
+      - $ref: '#/components/parameters/ZoneId'
+    get:
+      tags: [zones]
+      operationId: getZoneCreateFence
+      summary: Create fence from zone
+      description: Derives an approximate fence document from a zone definition.
+      responses:
+        '200':
+          description: Derived fence
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fence'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /v2/trackables:
     get:
       tags: [trackables]
@@ -156,6 +247,18 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Trackable'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    delete:
+      tags: [trackables]
+      operationId: deleteTrackables
+      summary: Delete all trackables
+      description: Removes all trackables known to the hub.
+      responses:
+        '204':
+          description: Deleted
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -180,6 +283,42 @@ paths:
                 $ref: '#/components/schemas/Trackable'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/trackables/summary:
+    get:
+      tags: [trackables]
+      operationId: getTrackablesSummary
+      summary: Get trackable summary
+      description: Returns a compact count of trackables known to the hub.
+      responses:
+        '200':
+          description: Trackable summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceSummary'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/trackables/motions:
+    get:
+      tags: [trackables]
+      operationId: getTrackableMotions
+      summary: List trackable motions
+      description: Returns all active trackable motions held in transient state.
+      responses:
+        '200':
+          description: Active trackable motions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrackableMotion'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -245,6 +384,140 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /v2/trackables/{trackableId}/fences:
+    parameters:
+      - $ref: '#/components/parameters/TrackableId'
+    get:
+      tags: [trackables]
+      operationId: getTrackableFences
+      summary: Get trackable fences
+      description: Returns fences that currently contain the trackable.
+      responses:
+        '200':
+          description: Active fence memberships
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Fence'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/trackables/{trackableId}/location:
+    parameters:
+      - $ref: '#/components/parameters/TrackableId'
+    get:
+      tags: [trackables]
+      operationId: getTrackableLocation
+      summary: Get trackable location
+      description: Returns the latest derived location known for the trackable.
+      responses:
+        '200':
+          description: Latest trackable location
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Location'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/trackables/{trackableId}/locations:
+    parameters:
+      - $ref: '#/components/parameters/TrackableId'
+    get:
+      tags: [trackables]
+      operationId: getTrackableLocations
+      summary: Get trackable locations
+      description: Returns active provider locations associated with the trackable.
+      responses:
+        '200':
+          description: Trackable provider locations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Location'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/trackables/{trackableId}/motion:
+    parameters:
+      - $ref: '#/components/parameters/TrackableId'
+    get:
+      tags: [trackables]
+      operationId: getTrackableMotion
+      summary: Get trackable motion
+      description: Returns the latest derived motion known for the trackable.
+      responses:
+        '200':
+          description: Latest trackable motion
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrackableMotion'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/trackables/{trackableId}/providers:
+    parameters:
+      - $ref: '#/components/parameters/TrackableId'
+    get:
+      tags: [trackables]
+      operationId: getTrackableProviders
+      summary: Get trackable providers
+      description: Returns providers assigned to the trackable.
+      responses:
+        '200':
+          description: Assigned providers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LocationProvider'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/trackables/{trackableId}/sensors:
+    parameters:
+      - $ref: '#/components/parameters/TrackableId'
+    get:
+      tags: [trackables]
+      operationId: getTrackableSensors
+      summary: Get trackable sensors
+      description: Returns provider sensor objects grouped by provider identifier.
+      responses:
+        '200':
+          description: Trackable sensors
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/ExtensionProperties'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /v2/providers:
     get:
       tags: [providers]
@@ -260,6 +533,18 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/LocationProvider'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    delete:
+      tags: [providers]
+      operationId: deleteProviders
+      summary: Delete all providers
+      description: Removes all location providers known to the hub.
+      responses:
+        '204':
+          description: Deleted
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -284,6 +569,23 @@ paths:
                 $ref: '#/components/schemas/LocationProvider'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/providers/summary:
+    get:
+      tags: [providers]
+      operationId: getProvidersSummary
+      summary: Get provider summary
+      description: Returns a compact count of location providers known to the hub.
+      responses:
+        '200':
+          description: Provider summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceSummary'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -349,7 +651,178 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /v2/providers/{providerId}/location:
+    parameters:
+      - $ref: '#/components/parameters/ProviderId'
+    get:
+      tags: [providers]
+      operationId: getProviderLocation
+      summary: Get provider location
+      description: Returns the latest active location known for the provider.
+      responses:
+        '200':
+          description: Latest provider location
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Location'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    put:
+      tags: [providers]
+      operationId: putProviderLocation
+      summary: Update provider location
+      description: Processes a single location update for the provider identifier in the path.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Location'
+      responses:
+        '202':
+          description: Accepted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    delete:
+      tags: [providers]
+      operationId: deleteProviderLocation
+      summary: Delete provider location
+      description: Clears active location and associated transient state for the provider.
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/providers/{providerId}/fences:
+    parameters:
+      - $ref: '#/components/parameters/ProviderId'
+    get:
+      tags: [providers]
+      operationId: getProviderFences
+      summary: Get provider fences
+      description: Returns fences containing the provider's latest active location.
+      responses:
+        '200':
+          description: Provider fences
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Fence'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/providers/{providerId}/sensors:
+    parameters:
+      - $ref: '#/components/parameters/ProviderId'
+    get:
+      tags: [providers]
+      operationId: getProviderSensors
+      summary: Get provider sensors
+      description: Returns the provider sensor extension object.
+      responses:
+        '200':
+          description: Provider sensors
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExtensionProperties'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    put:
+      tags: [providers]
+      operationId: putProviderSensors
+      summary: Update provider sensors
+      description: Replaces the provider sensor extension object.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: Updated provider
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationProvider'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/providers/{providerId}/proximity:
+    parameters:
+      - $ref: '#/components/parameters/ProviderId'
+    put:
+      tags: [providers]
+      operationId: putProviderProximity
+      summary: Update provider proximity
+      description: Processes a single proximity update for the provider identifier in the path.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Proximity'
+      responses:
+        '202':
+          description: Accepted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /v2/providers/locations:
+    get:
+      tags: [providers]
+      operationId: getProviderLocations
+      summary: Get provider locations
+      description: Returns all active latest provider locations held in transient state.
+      responses:
+        '200':
+          description: Active provider locations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Location'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
     post:
       tags: [providers]
       operationId: postProviderLocations
@@ -372,7 +845,63 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+    put:
+      tags: [providers]
+      operationId: putProviderLocations
+      summary: Replace provider locations
+      description: Processes a batch of provider location updates.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Location'
+      responses:
+        '202':
+          description: Accepted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    delete:
+      tags: [providers]
+      operationId: deleteProviderLocations
+      summary: Delete provider locations
+      description: Clears all active provider location state.
+      responses:
+        '204':
+          description: Deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /v2/providers/proximities:
+    put:
+      tags: [providers]
+      operationId: putProviderProximities
+      summary: Replace provider proximities
+      description: Processes a batch of proximity updates.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Proximity'
+      responses:
+        '202':
+          description: Accepted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
     post:
       tags: [providers]
       operationId: postProviderProximities
@@ -414,6 +943,18 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+    delete:
+      tags: [fences]
+      operationId: deleteFences
+      summary: Delete all fences
+      description: Removes all fences known to the hub.
+      responses:
+        '204':
+          description: Deleted
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
     post:
       tags: [fences]
       operationId: createFence
@@ -434,6 +975,23 @@ paths:
                 $ref: '#/components/schemas/Fence'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/fences/summary:
+    get:
+      tags: [fences]
+      operationId: getFencesSummary
+      summary: Get fence summary
+      description: Returns a compact count of fences known to the hub.
+      responses:
+        '200':
+          description: Fence summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceSummary'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -493,6 +1051,52 @@ paths:
       responses:
         '204':
           description: Deleted
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/fences/{fenceId}/providers:
+    parameters:
+      - $ref: '#/components/parameters/FenceId'
+    get:
+      tags: [fences]
+      operationId: getFenceProviders
+      summary: Get fence providers
+      description: Returns providers whose active latest locations are inside the fence.
+      responses:
+        '200':
+          description: Providers inside the fence
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LocationProvider'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /v2/fences/{fenceId}/locations:
+    parameters:
+      - $ref: '#/components/parameters/FenceId'
+    get:
+      tags: [fences]
+      operationId: getFenceLocations
+      summary: Get fence locations
+      description: Returns active latest locations inside the fence.
+      responses:
+        '200':
+          description: Locations inside the fence
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Location'
         '404':
           $ref: '#/components/responses/NotFound'
         '401':
@@ -636,6 +1240,19 @@ components:
         message:
           type: string
           description: Human-readable error message.
+
+    ResourceSummary:
+      type: object
+      description: Compact collection summary.
+      required: [type, count]
+      properties:
+        type:
+          type: string
+          description: Resource collection represented by the summary.
+        count:
+          type: integer
+          minimum: 0
+          description: Number of resources currently known to the hub.
 
     ExtensionProperties:
       type: object


### PR DESCRIPTION
## Summary

- expand the normative OpenAPI contract with the missing OMLOX v2 REST routes
- implement provider, trackable, fence, zone summary, transform, collection, and nested resource behavior
- expose transient provider and trackable location/motion state through REST
- regenerate the Go server bindings and add route coverage

## Why

Several OMLOX companion OpenAPI endpoints were absent from the repository contract and router, causing conforming requests such as `PUT /v2/providers/{providerId}/location` and `GET /v2/zones/summary` to return `404`.

## Validation

- `just bootstrap`
- `just generate`
- `go test ./internal/hub ./internal/httpapi/handlers ./cmd/hub`
- `git diff --check`

`go test ./...` passes for non-integration packages. Docker-backed integration tests could not run because Docker is unavailable in the current environment. `just check` reaches the generated-file cleanliness check, which reports the intentionally changed generated OpenAPI file against `HEAD`.